### PR TITLE
[IDP-3129] Reusable workflow to create releases from commits pushed since the last stable tag

### DIFF
--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -70,10 +70,6 @@ jobs:
             $major = 0; $minor = 0; $patch = 0
           } else {
             $parts = $lastTag -split '\.'
-            if ($parts.Length -ne 3) {
-              Write-Error "Tag '$lastTag' does not conform to x.y.z"
-              exit 1
-            }
             [int]$major = $parts[0]
             [int]$minor = $parts[1]
             [int]$patch = $parts[2]

--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -9,7 +9,7 @@ on:
         description: GitHub token with permissions to create releases. Prefer personal access tokens over default GitHub token, so tags created by this template can trigger other workflows.
 
 jobs:
-  create-release:
+  job:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to create a release

--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -79,23 +79,23 @@ jobs:
           $commitList = "${{ steps.get-commits.outputs.commit_list }}"
           
           # Determine bump level using regex (order: major, then minor, then patch)
-          if ($commitList -imatch '\+semver:\s?major') {
+          if ($commitList -imatch '#major') {
             Write-Host "Bumping major version."
             $major++
             $minor = 0
             $patch = 0
           }
-          elseif ($commitList -imatch '\+semver:\s?minor') {
+          elseif ($commitList -imatch '#minor') {
             Write-Host "Bumping minor version."
             $minor++
             $patch = 0
           }
-          elseif ($commitList -imatch '\+semver:\s?patch') {
+          elseif ($commitList -imatch '#patch') {
             Write-Host "Bumping patch version."
             $patch++
           }
           else {
-            Write-Host "No semver directive found. Defaulting to bump patch version."
+            Write-Host "No version bump tag found. Defaulting to bump patch version."
             $patch++
           }
           $newVersion = "$major.$minor.$patch"

--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -1,0 +1,116 @@
+# Automatically create new releases from the main branch when there are new commits since the last stable release.
+name: Create stable release
+
+on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+        description: GitHub token with permissions to create releases. Prefer personal access tokens over default GitHub token, so tags created by this template can trigger other workflows.
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create a release
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Get latest stable tag
+        id: get-latest-tag
+        shell: pwsh
+        run: |
+          # Get all tags sorted in natural order, then filter for stable versions (x.y.z)
+          $tag = git tag --sort=-v:refname | Where-Object { $_ -match '^\d+\.\d+\.\d+$' } | Select-Object -First 1
+          Write-Host "Latest stable tag: $tag"
+          if (-not $tag) { $tag = "" }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$tag"
+
+      - name: Get commits since last stable tag
+        id: get-commits
+        shell: pwsh
+        run: |
+          $tag = "${{ steps.get-latest-tag.outputs.tag }}"
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            Write-Host "No stable tag found. Considering all commits."
+            $commitRange = "HEAD"
+          } else {
+            $commitRange = "$tag..HEAD"
+          }
+          # Get commit messages as a Markdown list
+          $commitMessages = git log $commitRange --pretty=format:'- %s'
+          
+          # Gracefully exit if no commits found
+          if ([string]::IsNullOrWhiteSpace($commitMessages)) {
+            Write-Host "No new commits found since last stable tag. Exiting."
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "has_commits=false"
+            exit 0
+          }
+          
+          Write-Host "Commit messages:`n$commitMessages"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "commit_list<<EOF"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value $commitMessages
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "EOF"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "has_commits=true"
+
+      - name: Compute new version
+        id: compute-version
+        if: steps.get-commits.outputs.has_commits == 'true'
+        shell: pwsh
+        run: |
+          # Retrieve the last stable tag; if not found, start with 0.0.0
+          $lastTag = "${{ steps.get-latest-tag.outputs.tag }}"
+          if ([string]::IsNullOrWhiteSpace($lastTag)) {
+            Write-Host "No stable tag found. Using 0.0.0 as baseline."
+            $major = 0; $minor = 0; $patch = 0
+          } else {
+            $parts = $lastTag -split '\.'
+            if ($parts.Length -ne 3) {
+              Write-Error "Tag '$lastTag' does not conform to x.y.z"
+              exit 1
+            }
+            [int]$major = $parts[0]
+            [int]$minor = $parts[1]
+            [int]$patch = $parts[2]
+          }
+
+          # Read commit messages collected earlier
+          $commitList = "${{ steps.get-commits.outputs.commit_list }}"
+          
+          # Determine bump level using regex (order: major, then minor, then patch)
+          if ($commitList -imatch '\+semver:\s?major') {
+            Write-Host "Bumping major version."
+            $major++
+            $minor = 0
+            $patch = 0
+          }
+          elseif ($commitList -imatch '\+semver:\s?minor') {
+            Write-Host "Bumping minor version."
+            $minor++
+            $patch = 0
+          }
+          elseif ($commitList -imatch '\+semver:\s?patch') {
+            Write-Host "Bumping patch version."
+            $patch++
+          }
+          else {
+            Write-Host "No semver directive found. Defaulting to bump patch version."
+            $patch++
+          }
+          $newVersion = "$major.$minor.$patch"
+          Write-Host "New version: $newVersion"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "version=$newVersion"
+
+      - name: Create GitHub Release
+        if: steps.get-commits.outputs.has_commits == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+        run: |
+          $version = "${{ steps.compute-version.outputs.version }}"
+          gh release create $version --title $version --generate-notes --fail-on-no-commits

--- a/README.md
+++ b/README.md
@@ -70,6 +70,41 @@ This workflow runs TF-Lint to find issues in the code, Terraform-Docs to create 
 
 This workflow creates a new Git tag.
 
+## Create GitHub releases from commits available since the last stable release
+
+This reusable workflow is useful because we often forget to create new GitHub releases for libraries after merging pull requests. It is intended to be used with a schedule. It requires a secret named `token` that contains a personal access token with permissions to create GitHub releases on the targeted repo (`contents: write`).
+
+Supports semantic commits containing matching the following regexes:
+
+- `\+semver:\s?major`: if any commit matches this regex, it will bump the major version,
+- `\+semver:\s?minor`: if any commit matches this regex, it will bump the minor version,
+- `\+semver:\s?patch`: if any commit matches this regex, it will bump the patch version (default behavior).
+
+Additional features and behaviors:
+
+- Supports new repos without tags (will create `0.0.1`).
+- Gracefully exits if there's no commits since the last stable tag.
+- Automatically generates the release notes.
+- Only supports creating tags from the main branch of the targeted repo.
+
+Here's how to use it:
+
+```yaml
+name: Create stable release
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # At 03:00 on Sunday (that's an example)
+
+jobs:
+  create-release:
+    permissions:
+      contents: write
+    uses: workleap/wl-reusable-workflows/.github/workflows/create-stable-release.yml
+    secrets:
+      token: ${{ secrets.SOME_PAT }}
+```
+
 ## License
 
-Copyright © 2024, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.
+Copyright © 2025, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ This workflow creates a new Git tag.
 
 This reusable workflow is useful because we often forget to create new GitHub releases for libraries after merging pull requests. It is intended to be used with a schedule. It requires a secret named `token` that contains a personal access token with permissions to create GitHub releases on the targeted repo (`contents: write`).
 
-Supports semantic commits containing matching the following regexes:
-
+Supports semantic commits matching the following regexes:
 - `\+semver:\s?major`: if any commit matches this regex, it will bump the major version,
 - `\+semver:\s?minor`: if any commit matches this regex, it will bump the minor version,
 - `\+semver:\s?patch`: if any commit matches this regex, it will bump the patch version (default behavior).

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ This workflow creates a new Git tag.
 
 This reusable workflow is useful because we often forget to create new GitHub releases for libraries after merging pull requests. It is intended to be used with a schedule. It requires a secret named `token` that contains a personal access token with permissions to create GitHub releases on the targeted repo (`contents: write`).
 
-Supports semantic commits matching the following regexes:
-- `\+semver:\s?major`: if any commit matches this regex, it will bump the major version,
-- `\+semver:\s?minor`: if any commit matches this regex, it will bump the minor version,
-- `\+semver:\s?patch`: if any commit matches this regex, it will bump the patch version (default behavior).
+If any commit message contains the following keywords, it will create a new release with the corresponding version bump:
+- `#major`: bump the major version,
+- `#minor`: bump the minor version,
+- `#patch`: bump the patch version (default behavior).
 
 Additional features and behaviors:
 


### PR DESCRIPTION
This pull request introduces a reusable workflow to create stable releases from the main branch whenever there are new commits. The key changes include setting up the workflow, fetching the latest stable tag, collecting commit messages, determining the new version based on commit messages, and creating a GitHub release. Updated README.

Developed with the help of ChatGPT and Copilot Edits in VS Code. Tested locally with [nektos/act](https://github.com/nektos/act) at the beginning, then with an actual private repo of mine referencing this new reusable pipeline in this branch.

Supports version bumps according to the commit messages:

- `#major`: bump major
- `#minor`: bump minor
- `#patch`: bump patch (default behavior)

Additional features and behavior:

- Supports new repos without tags (will create `0.0.1`).
- Gracefully exits if there's no commits since the last stable tag.
- Automatically generates the release notes.
- Only supports the main branch. Can't create tags from other branches.
- Authentication token has to be provided by IT on the consumer side. Default GitHub tokens don't trigger `push` events when creating tags. Personal access token do, so our existing publish pipelines can react to them.

The reusable workflow can be used like this:

```yaml
name: Create stable release

on:
  schedule:
    - cron: "0 3 * * 0" # At 03:00 on Sunday

jobs:
  create-release:
    permissions:
      contents: write
    uses: workleap/wl-reusable-workflows/.github/workflows/create-stable-release.yml
    secrets:
      token: ${{ secrets.SOME_PAT }}
```

Here's a run:

![image](https://github.com/user-attachments/assets/f62802ee-edb5-43ef-a51e-2ed4e3578e87)
