### PR TITLE
IDP-3275 Add actions: read perm to semgrep workflow

### DIFF
--- a/.github/workflows/reusable-semgrep-workflow.yml
+++ b/.github/workflows/reusable-semgrep-workflow.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
       security-events: write
 
     container:


### PR DESCRIPTION
This permission is required according to the documentation: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository