### PR TITLE
IDP-3392 Don't run terraform login

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -114,7 +114,6 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ steps.get_secrets.outputs.tf_token_app_terraform_io }}
         run: |
-          terraform login
           terraform init
           terraform validate
         
@@ -138,6 +137,5 @@ jobs:
           TF_TOKEN_app_terraform_io: ${{ steps.get_secrets.outputs.tf_token_app_terraform_io }}
         run: |
           cd "./tests"
-          terraform login
           terraform init
           terraform test

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -89,18 +89,15 @@ jobs:
   terraform-validate-and-tests:
     runs-on: [self-hosted, idp-infra]
     steps:
-      - name: 'Azure CLI login'
-        uses: azure/login@v2
+      - name: Get terraform cloud token
+        id: get_terraform_cloud_token
+        uses: workleap/wl-reusable-workflows/retrieve-managed-secret@main
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Get Secrets from Azure Key Vault
-        id: get_secrets
-        run: |
-          # Set env.TERRAFORM_CLOUD_TOKEN
-          TF_TOKEN_app_terraform_io=$(az keyvault secret show --vault-name ${{ vars.IDP_CICD_KEYVAULT_NAME }} --name "renovate-tfc-token" --query value -o tsv)
+          azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          keyvault-name: ${{ vars.IDP_CICD_KEYVAULT_NAME }}
+          secret-name: "renovate-tfc-toke"
 
       - uses: actions/checkout@v4
         name: Checkout source code
@@ -112,7 +109,7 @@ jobs:
         id: terraform-validate
         shell: bash
         env:
-          TF_TOKEN_app_terraform_io: ${{ steps.get_secrets.outputs.tf_token_app_terraform_io }}
+          TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
           terraform init
           terraform validate
@@ -134,7 +131,7 @@ jobs:
         if: steps.check-tests.outputs.has_tests == 'true'
         shell: bash
         env:
-          TF_TOKEN_app_terraform_io: ${{ steps.get_secrets.outputs.tf_token_app_terraform_io }}
+          TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
           cd "./tests"
           terraform init

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -97,7 +97,7 @@ jobs:
           azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           keyvault-name: ${{ vars.IDP_CICD_KEYVAULT_NAME }}
-          secret-name: "renovate-tfc-toke"
+          secret-name: "renovate-tfc-token"
 
       - uses: actions/checkout@v4
         name: Checkout source code


### PR DESCRIPTION
According to [the docs](https://developer.hashicorp.com/terraform/cli/config/config-file), it seems like we don't need to run a terraform login command if `TF_TOKEN_*` is specified. Also, `terraform login` without any arguments is an interactive command that causes the workflow to hang.