### PR TITLE
Support `pull_request` and `push` in terraform-docs-fmt

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # If this is a pull request (detached HEAD state), switch to the branch being PR'd. Othewise use the current ref.
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           token: ${{ steps.auth.outputs.token }}
           
       - name: Setup Terraform


### PR DESCRIPTION
When triggering this workflow on `pull_request` (so that the oidc token is generated with the `pull_request` suject, the repo is checked out in a detached HEAD state which makes it not possible to commit and push it back to the source branch. We need to switch to the branch being PR'd. We also stay on the normal branch if this is not a `pull_request` for backwards compatibility.