### PR TITLE
Set script to create and merge PRs

### DIFF
--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -100,7 +100,8 @@ jobs:
           git add .github/ CONTRIBUTING.md SECURITY.md renovate.json
           if (-not (git diff --staged --quiet)) {
               git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
-              git push origin main
+              gh pr create --fill
+              gh pr merge --admin --squash --delete-branch
           } else {
               Write-Output "No changes to commit"
           }

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -100,8 +100,9 @@ jobs:
           git add .github/ CONTRIBUTING.md SECURITY.md renovate.json
           if (-not (git diff --staged --quiet)) {
               git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
-              gh pr create --fill
-              gh pr merge --admin --squash --delete-branch
+              git push -u origin HEAD
+              gh pr create --fill --base main
+              gh pr merge --admin --squash --delete-branch  --repo workleap/${{ matrix.repo }} --base main
           } else {
               Write-Output "No changes to commit"
           }


### PR DESCRIPTION
This pull request updates the workflow for syncing template files to streamline the process of handling changes. Instead of directly pushing to the `main` branch, the workflow now creates and merges a pull request using GitHub CLI commands.

Key change:

* [`.github/workflows/github-template-update-downstream.yml`](diffhunk://#diff-69eb4e7e8ccc7ae43deeb66f9702ff839ccbc08a3009f90f7273a1639b0aa719L103-R104): Replaced the direct `git push origin main` command with `gh pr create --fill` and `gh pr merge --admin --squash --delete-branch` to create a pull request, merge it with admin privileges, squash commits, and delete the branch afterward.