### PR TITLE
Fix PR creation and merge to main

### DIFF
--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -95,12 +95,10 @@ jobs:
 
           $excludePattern = ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
           git restore --source=template --staged --worktree CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
-          $temp = git diff --staged
-          Write-Host "temp = $temp"
+          $staged = git diff --cached --name-only
+          Write-Host "staged = $staged."
 
-          # Stage and commit if there are changes
-          git add CONTRIBUTING.md SECURITY.md renovate.json .github/
-          if (-not (git diff --staged --quiet)) {
+          if ($staged)) {
             git switch -c sync-template
             git pull
             git commit -m "Sync template files from ${{ inputs.templateRepoName }}"

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -21,6 +21,11 @@ on:
         default: ''
         required: false
 
+permissions:
+  pull-requests: write
+  contents: read
+  repository-projects: read
+
 jobs:
   get-repos:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           fetch-depth: 0
           path: template
-          branch: main
       
       - name: Checkout Downstream
         uses: actions/checkout@v4
@@ -82,7 +81,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
       
       - name: Merge Template Changes
-        if: ${{ !contains(inputs.ignoreRepos, matrix.repo) }}
+        if: ${{ !contains(inputs.ignoreRepos, matrix.repo) && matrix.repo != inputs.templateRepoName }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -100,6 +99,7 @@ jobs:
 
           # Create a dedicated sync branch
           git switch -c sync-template
+          git pull
 
           # Stage and commit if there are changes
           git add CONTRIBUTING.md SECURITY.md renovate.json .github/

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           fetch-depth: 0
           path: template
+          branch: main
       
       - name: Checkout Downstream
         uses: actions/checkout@v4
@@ -94,10 +95,10 @@ jobs:
           git fetch --no-tags template
 
           # Restore template files except the workflow file
-          git restore --source=template -- CONTRIBUTING.md SECURITY.md renovate.json .github/
-          git restore --source=template -- . ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
+          $excludePattern = ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
+          git restore --source=template -- CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
 
-          # Create a dedicated sync branch (avoids direct pushes to main)
+          # Create a dedicated sync branch
           git switch -c sync-template
 
           # Stage and commit if there are changes

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -91,11 +91,11 @@ jobs:
 
           # Add and fetch the template remote
           git remote add template ../template
-          git fetch --no-tags template/main
+          git fetch --no-tags template
 
           # Restore template files except the workflow file
-          git restore --source=template/main -- CONTRIBUTING.md SECURITY.md renovate.json .github/
-          git restore --source=template/main -- . ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
+          git restore --source=template -- CONTRIBUTING.md SECURITY.md renovate.json .github/
+          git restore --source=template -- . ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
 
           # Create a dedicated sync branch (avoids direct pushes to main)
           git switch -c sync-template

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -21,10 +21,6 @@ on:
         default: ''
         required: false
 
-permissions:
-  #contents: write
-  pull-requests: write
-
 jobs:
   get-repos:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -100,7 +100,8 @@ jobs:
           # Create a dedicated sync branch
           git switch -c sync-template
           write-host "test-test-test"
-          git diff --staged
+          $temp = git diff --staged --quiet
+          write-host "temp: $temp"
           git pull
 
           # Stage and commit if there are changes

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -93,22 +93,17 @@ jobs:
           git remote add template ../template
           git fetch --no-tags template
 
-          # Restore template files except the workflow file
           $excludePattern = ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
-          git restore --source=template --staged CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
-
-          # Create a dedicated sync branch
-          git switch -c sync-template
+          git restore --source=template --staged --worktree CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
           $temp = git diff --staged
-          write-host "temp: $temp"
-          git pull
+          Write-Host "temp = $temp"
 
           # Stage and commit if there are changes
           git add CONTRIBUTING.md SECURITY.md renovate.json .github/
           if (-not (git diff --staged --quiet)) {
+            git switch -c sync-template
+            git pull
             git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
-
-            # Push to feature branch and open a PR
             git push -u origin sync-template
             gh pr create `
               --repo workleap/${{ matrix.repo }} `

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -86,6 +86,7 @@ jobs:
 
           # Add and fetch the template remote
           git remote add template ../template
+          git fetch template
 
           # Create a dedicated sync branch (avoids direct pushes to main)
           git switch -c sync-template

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -98,7 +98,7 @@ jobs:
           $staged = git diff --cached --name-only
           Write-Host "staged = $staged."
 
-          if ($staged)) {
+          if ($staged) {
             git switch -c sync-template
             git pull
             git commit -m "Sync template files from ${{ inputs.templateRepoName }}"

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -91,7 +91,7 @@ jobs:
 
           # Add and fetch the template remote
           git remote add template ../template
-          git fetch --no-tags template +refs/heads/main:refs/remotes/template/main
+          git fetch --no-tags template +refs/heads/*:refs/remotes/template/*
 
           # Restore template files except the workflow file
           git restore --source=template/main -- CONTRIBUTING.md SECURITY.md renovate.json .github/

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -45,6 +45,9 @@ jobs:
   sync:
     needs: get-repos
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       matrix:
         repo: ${{ fromJson(needs.get-repos.outputs.repos) }}
@@ -86,7 +89,6 @@ jobs:
 
           # Add and fetch the template remote
           git remote add template ../template
-          git fetch template
 
           # Create a dedicated sync branch (avoids direct pushes to main)
           git switch -c sync-template

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -99,6 +99,7 @@ jobs:
 
           # Create a dedicated sync branch
           git switch -c sync-template
+          git diff --staged
           git pull
 
           # Stage and commit if there are changes

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -95,11 +95,10 @@ jobs:
 
           # Restore template files except the workflow file
           $excludePattern = ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
-          git restore --source=template -- CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
+          git restore --source=template --staged CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
 
           # Create a dedicated sync branch
           git switch -c sync-template
-          write-host "test-test-test"
           $temp = git diff --staged
           write-host "temp: $temp"
           git pull

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -79,33 +79,44 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          
-          # Check if current repository should be skipped
-          if ("${{ inputs.ignoreRepos }}" -ne "") {
-            $ignoreRepos = "${{ inputs.ignoreRepos }}".Split(',')
-            if ($ignoreRepos -contains "${{ matrix.repo }}") {
-              Write-Output "Skipping repository ${{ matrix.repo }} as it's in the ignore list"
-              exit 0
-            }
-          }
 
+          # Move into the downstream clone
           Set-Location downstream
+
+          # Add and fetch the template remote
           git remote add template ../template
           git fetch template
-          
-          $excludePattern = ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
-          
-          git restore --source=template/main -- CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
 
-          git add .github/ CONTRIBUTING.md SECURITY.md renovate.json
+          # Create a dedicated sync branch (avoids direct pushes to main)
+          git switch -c sync-template
+
+          # Restore template files except the workflow file
+          git restore --source=template/main -- CONTRIBUTING.md SECURITY.md renovate.json .github/
+          git restore --source=template/main -- . ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
+
+          # Stage and commit if there are changes
+          git add CONTRIBUTING.md SECURITY.md renovate.json .github/
           if (-not (git diff --staged --quiet)) {
-              git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
-              git push -u origin HEAD
-              gh pr create --fill --base main
-              gh pr merge --admin --squash --delete-branch  --repo workleap/${{ matrix.repo }} --base main
+            git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
+
+            # Push to feature branch and open a PR
+            git push -u origin sync-template
+            gh pr create \
+              --repo workleap/${{ matrix.repo }} \
+              --base main \
+              --head sync-template \
+              --fill    # opens PR with default title/body :contentReference[oaicite:1]{index=1}
+
+            # Merge non-interactively, bypassing checks, squash, and delete branch
+            gh pr merge sync-template \
+              --repo workleap/${{ matrix.repo }} \
+              --admin \
+              --squash \
+              --delete-branch   # uses CLI flags for merge and cleanup :contentReference[oaicite:2]{index=2}
+
           } else {
-              Write-Output "No changes to commit"
+            Write-Output "No changes to commit"
           }
-          
+
         env:
           GH_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -107,7 +107,8 @@ jobs:
               --repo workleap/${{ matrix.repo }} `
               --base main `
               --head sync-template `
-              --fill
+              --title "Sync template files from ${{ inputs.templateRepoName }}" `
+              --body "Automated sync of CONTRIBUTING.md, SECURITY.md, renovate.json and workflows."
 
             # Merge non-interactively, bypassing checks, squash, and delete branch
             gh pr merge sync-template `

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -102,18 +102,18 @@ jobs:
 
             # Push to feature branch and open a PR
             git push -u origin sync-template
-            gh pr create \
-              --repo workleap/${{ matrix.repo }} \
-              --base main \
-              --head sync-template \
-              --fill    # opens PR with default title/body :contentReference[oaicite:1]{index=1}
+            gh pr create `
+              --repo workleap/${{ matrix.repo }} `
+              --base main `
+              --head sync-template `
+              --fill
 
             # Merge non-interactively, bypassing checks, squash, and delete branch
-            gh pr merge sync-template \
-              --repo workleap/${{ matrix.repo }} \
-              --admin \
-              --squash \
-              --delete-branch   # uses CLI flags for merge and cleanup :contentReference[oaicite:2]{index=2}
+            gh pr merge sync-template `
+              --repo workleap/${{ matrix.repo }} `
+              --admin `
+              --squash `
+              --delete-branch
 
           } else {
             Write-Output "No changes to commit"

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -99,6 +99,7 @@ jobs:
 
           # Create a dedicated sync branch
           git switch -c sync-template
+          write-host "test-test-test"
           git diff --staged
           git pull
 

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -21,6 +21,10 @@ on:
         default: ''
         required: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   get-repos:
     runs-on: ubuntu-latest
@@ -45,9 +49,6 @@ jobs:
   sync:
     needs: get-repos
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     strategy:
       matrix:
         repo: ${{ fromJson(needs.get-repos.outputs.repos) }}

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -76,6 +76,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
       
       - name: Merge Template Changes
+        if: ${{ !contains(inputs.ignoreRepos, matrix.repo) }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -100,6 +100,7 @@ jobs:
           # Create a dedicated sync branch
           git switch -c sync-template
           git pull
+          git diff --staged
 
           # Stage and commit if there are changes
           git add CONTRIBUTING.md SECURITY.md renovate.json .github/

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -22,7 +22,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  #contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -91,7 +91,7 @@ jobs:
 
           # Add and fetch the template remote
           git remote add template ../template
-          git fetch --no-tags template +refs/heads/*:refs/remotes/template/*
+          git fetch --no-tags template/main
 
           # Restore template files except the workflow file
           git restore --source=template/main -- CONTRIBUTING.md SECURITY.md renovate.json .github/

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -21,6 +21,9 @@ on:
         default: ''
         required: false
 
+permissions:
+  pull-requests: write
+
 jobs:
   get-repos:
     runs-on: ubuntu-latest
@@ -86,14 +89,14 @@ jobs:
 
           # Add and fetch the template remote
           git remote add template ../template
-          git fetch template
-
-          # Create a dedicated sync branch (avoids direct pushes to main)
-          git switch -c sync-template
+          git fetch --no-tags template +refs/heads/main:refs/remotes/template/main
 
           # Restore template files except the workflow file
           git restore --source=template/main -- CONTRIBUTING.md SECURITY.md renovate.json .github/
           git restore --source=template/main -- . ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
+
+          # Create a dedicated sync branch (avoids direct pushes to main)
+          git switch -c sync-template
 
           # Stage and commit if there are changes
           git add CONTRIBUTING.md SECURITY.md renovate.json .github/
@@ -101,7 +104,6 @@ jobs:
             git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
 
             # Push to feature branch and open a PR
-            git fetch origin main
             git push -u origin sync-template
             gh pr create `
               --repo workleap/${{ matrix.repo }} `

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -110,8 +110,6 @@ jobs:
             git push -u origin sync-template
             gh pr create `
               --repo workleap/${{ matrix.repo }} `
-              --base main `
-              --head sync-template `
               --title "Sync template files from ${{ inputs.templateRepoName }}" `
               --body "Automated sync of CONTRIBUTING.md, SECURITY.md, renovate.json and workflows."
 

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -100,7 +100,7 @@ jobs:
           # Create a dedicated sync branch
           git switch -c sync-template
           write-host "test-test-test"
-          $temp = git diff --staged --quiet
+          $temp = git diff --staged
           write-host "temp: $temp"
           git pull
 

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -100,7 +100,6 @@ jobs:
           # Create a dedicated sync branch
           git switch -c sync-template
           git pull
-          git diff --staged
 
           # Stage and commit if there are changes
           git add CONTRIBUTING.md SECURITY.md renovate.json .github/
@@ -111,6 +110,8 @@ jobs:
             git push -u origin sync-template
             gh pr create `
               --repo workleap/${{ matrix.repo }} `
+              --base main `
+              --head sync-template `
               --title "Sync template files from ${{ inputs.templateRepoName }}" `
               --body "Automated sync of CONTRIBUTING.md, SECURITY.md, renovate.json and workflows."
 

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -101,6 +101,7 @@ jobs:
             git commit -m "Sync template files from ${{ inputs.templateRepoName }}"
 
             # Push to feature branch and open a PR
+            git fetch origin main
             git push -u origin sync-template
             gh pr create `
               --repo workleap/${{ matrix.repo }} `

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -21,9 +21,6 @@ on:
         default: ''
         required: false
 
-permissions:
-  pull-requests: write
-
 jobs:
   get-repos:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-template-update-downstream.yml
+++ b/.github/workflows/github-template-update-downstream.yml
@@ -96,7 +96,6 @@ jobs:
           $excludePattern = ":(exclude).github/workflows/${{ inputs.workflowFileName }}"
           git restore --source=template --staged --worktree CONTRIBUTING.md SECURITY.md renovate.json .github/ $excludePattern
           $staged = git diff --cached --name-only
-          Write-Host "staged = $staged."
 
           if ($staged) {
             git switch -c sync-template


### PR DESCRIPTION
This pull request updates the workflow for syncing template changes to downstream repositories. The changes streamline the process by introducing a conditional check for ignored repositories, creating a dedicated sync branch, and improving the handling of pull requests and merges.

### Workflow improvements:

* Added a conditional check (`if: ${{ !contains(inputs.ignoreRepos, matrix.repo) }}`) to skip processing for repositories listed in the `ignoreRepos` input, simplifying the logic and removing redundant PowerShell code.
* Introduced the creation of a dedicated `sync-template` branch to avoid direct pushes to the `main` branch during template synchronization.
* Updated the pull request creation process to use the `gh pr create` command with the `--fill` flag for default title and body, ensuring consistency and reducing manual input.
* Enhanced the merge process by using the `gh pr merge` command with flags for administrative privileges, squash merging, and automatic branch deletion, streamlining the workflow and ensuring cleanup.
* Adjusted the file restoration logic to exclude the workflow file (`:${{ inputs.workflowFileName }}`) in a more concise and maintainable manner.