### PR TITLE
Add URL to check details in error messages

### DIFF
--- a/.github/workflows/required_checks_policy.yml
+++ b/.github/workflows/required_checks_policy.yml
@@ -199,7 +199,7 @@ jobs:
                         else {
                             $completed = $false
                             if ((Get-Date -AsUTC) - $startedAt -gt $TimeoutCreated) {
-                                Write-Error "❌ Check '$requiredCheck' is not created after $($Timeout.TotalMinutes) minutes."
+                                Write-Error "❌ Check '$requiredCheck' is not created after $($TimeoutCreated.TotalMinutes) minutes."
                                 exit 1
                             }
                         }


### PR DESCRIPTION
Include the URL to the check details in error messages for failed or queued checks, enhancing the clarity and usefulness of the output.