### PR TITLE
Create tag only when TF files are modified

### DIFF
--- a/.github/workflows/terraform-create-git-tag.yml
+++ b/.github/workflows/terraform-create-git-tag.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: [idp]
     permissions:
       contents: write
     steps:
@@ -20,7 +20,17 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+    - name: Detect changed .tf files
+      id: detect_tf
+      run: |
+        if git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.merge_commit_sha }} | grep -E '\.tf$'; then
+          echo "tf_changed=true" >> $GITHUB_OUTPUT
+        else
+          echo "tf_changed=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Bump version and push tag
+      if: ${{ steps.detect_tf.outputs.tf_changed == 'true' }}
       uses: anothrNick/github-tag-action@1.73.0
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for creating Terraform-related git tags. The changes include modifying the runner, adding a step to detect changes in `.tf` files, and conditionally executing the version bump and tagging step based on those changes.

### Workflow updates:

* **Runner update**: Changed the `runs-on` property from `ubuntu-latest` to `[idp]`, likely to use a custom or self-hosted runner. (`.github/workflows/terraform-create-git-tag.yml`, [.github/workflows/terraform-create-git-tag.ymlL9-R9](diffhunk://#diff-fd32240d9d325e9b75e6fc990d5e0e5164e6bf1e32e35f399fcc43b86eb48538L9-R9))
* **Detect `.tf` file changes**: Added a new step to detect whether `.tf` files were modified in the merged pull request. This step sets an output variable `tf_changed` to `true` or `false`. (`.github/workflows/terraform-create-git-tag.yml`, [.github/workflows/terraform-create-git-tag.ymlR23-R33](diffhunk://#diff-fd32240d9d325e9b75e6fc990d5e0e5164e6bf1e32e35f399fcc43b86eb48538R23-R33))
* **Conditional tagging**: Updated the "Bump version and push tag" step to execute only if `.tf` files were changed, using the output from the detection step. (`.github/workflows/terraform-create-git-tag.yml`, [.github/workflows/terraform-create-git-tag.ymlR23-R33](diffhunk://#diff-fd32240d9d325e9b75e6fc990d5e0e5164e6bf1e32e35f399fcc43b86eb48538R23-R33))