### PR TITLE
Hotfix/feng 708 001

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -27,8 +27,8 @@ jobs:
         
       - name: Terraform Format
         run: terraform fmt -recursive
-        
-      - name: Run Terraform Docs
+
+      - name: Terraform Docs
         run: terraform-docs markdown table --output-file README.md --hide resources,data-sources .
 
       - name: Commit file updates


### PR DESCRIPTION
Jira issue link: [FENG-708](https://workleap.atlassian.net/browse/FENG-708)

This pull request updates the Terraform documentation generation process in the GitHub Actions workflow. The change simplifies the method used to render Terraform docs in the `README.md` file.

### Updates to Terraform documentation generation:

* [`.github/workflows/terraform-on-branch-push.yml`](diffhunk://#diff-f99d7c5102c3226875e2e3efd95b30ff80e52179221bf1d81d8d94d14eb726e4L31-R32): Replaced the `terraform-docs/gh-actions` GitHub Action with a direct `terraform-docs` CLI command to generate a markdown table and hide specific sections (`resources` and `data-sources`) in the `README.md` file.