### PR TITLE
Use ubuntu-latest to fix tag creation

### DIFF
--- a/.github/workflows/terraform-create-git-tag.yml
+++ b/.github/workflows/terraform-create-git-tag.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     if: github.event.pull_request.merged == true
-    runs-on: [idp]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Jira issue link: [feng-708](https://workleap.atlassian.net/browse/feng-708)

This pull request updates the GitHub Actions workflow configuration to improve compatibility and maintainability.

### Workflow configuration changes:

* [`.github/workflows/terraform-create-git-tag.yml`](diffhunk://#diff-fd32240d9d325e9b75e6fc990d5e0e5164e6bf1e32e35f399fcc43b86eb48538L9-R9): Updated the `runs-on` property from `[idp]` to `ubuntu-latest` to ensure compatibility with a broader range of environments and improve maintainability.