### PR TITLE
Hotfix/feng 708 1

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Commit file updates
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
-          add: '["**/*.md", "**/*.tf", "**/*.tfvars"]'
           author_name: github-actions[bot]
           author_email: github-actions[bot]@users.noreply.github.com
           default_author: github_actions

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -39,6 +39,7 @@ jobs:
           message: 'chore: apply formatting and docs update'
           push: true
           fetch: true
+          pull: '--no-rebase'
 
   tflint:
     name: Terraform lint

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -3,6 +3,7 @@ on: workflow_call
 
 jobs:
   terraform-doc-fmt:
+    name: Terraform formatting & docs
     runs-on: [idp]
     permissions:
       contents: write
@@ -11,7 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # If this is a pull request (detached HEAD state), switch to the branch being PR'd. Othewise use the current ref.
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           fetch-depth: 0
           
@@ -40,6 +40,7 @@ jobs:
           push: true
 
   tflint:
+    name: Terraform lint
     runs-on: [idp]
     steps:
       - name: Authenticate with GitHub App
@@ -77,6 +78,7 @@ jobs:
         run: tflint -f compact
         
   terraform-validate-and-tests:
+    name: Terraform validate and tests
     runs-on: [idp]
     steps:
       - name: Get terraform cloud token

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           # If this is a pull request (detached HEAD state), switch to the branch being PR'd. Othewise use the current ref.
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          token: ${{ steps.auth.outputs.token }}
           fetch-depth: 0
           
       - name: Setup Terraform

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -38,6 +38,7 @@ jobs:
           default_author: github_actions
           message: 'chore: apply formatting and docs update'
           push: true
+          fetch: true
 
   tflint:
     name: Terraform lint

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -24,11 +24,6 @@ jobs:
       - name: Terraform Docs
         run: terraform-docs markdown table --output-file README.md --hide resources,data-sources .
 
-      - name: Show README changes
-        run: |
-          git diff README.md
-          git status
-
       - name: Commit file updates
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -7,20 +7,14 @@ jobs:
     permissions:
       contents: write
     continue-on-error: true
-    steps:
-      - name: Authenticate with GitHub App
-        id: auth
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.TERRAFORM_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.TERRAFORM_AUTOMATION_PRIVATE_KEY }}
-          
+    steps:          
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           # If this is a pull request (detached HEAD state), switch to the branch being PR'd. Othewise use the current ref.
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           token: ${{ steps.auth.outputs.token }}
+          fetch-depth: 0
           
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -30,6 +24,11 @@ jobs:
 
       - name: Terraform Docs
         run: terraform-docs markdown table --output-file README.md --hide resources,data-sources .
+
+      - name: Show README changes
+        run: |
+          git diff README.md
+          git status
 
       - name: Commit file updates
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @workleap/internal-developer-platform @workleap/infrastructure
+* @workleap/internal-developer-platform @workleap/foundation-engineering-infrastructure


### PR DESCRIPTION
Jira issue link: [FENG-708](https://workleap.atlassian.net/browse/FENG-708)

This pull request updates the `.github/workflows/terraform-on-branch-push.yml` file to improve the Terraform workflow by enhancing job configurations, simplifying steps, and ensuring better compatibility. The most important changes include adding descriptive job names, removing unnecessary authentication steps, and adjusting configurations for file updates and repository checkout.

### Workflow Enhancements:

* Added descriptive names for jobs (`terraform-doc-fmt`, `tflint`, and `terraform-validate-and-tests`) to improve readability and clarity in the workflow logs. [[1]](diffhunk://#diff-f99d7c5102c3226875e2e3efd95b30ff80e52179221bf1d81d8d94d14eb726e4R6-R16) [[2]](diffhunk://#diff-f99d7c5102c3226875e2e3efd95b30ff80e52179221bf1d81d8d94d14eb726e4L37-R39) [[3]](diffhunk://#diff-f99d7c5102c3226875e2e3efd95b30ff80e52179221bf1d81d8d94d14eb726e4R77)

### Simplification and Streamlining:

* Removed the GitHub App authentication step (`actions/create-github-app-token@v2`) from the `terraform-doc-fmt` job, simplifying the workflow.
* Adjusted the `checkout` step to use `fetch-depth: 0` for complete repository history instead of relying on a token from the removed authentication step.

### Configuration Improvements:

* Updated the `add-and-commit` action in the `terraform-doc-fmt` job to include `fetch: true` and `pull: '--no-rebase'` for better handling of file updates and synchronization.