### PR TITLE
Add auth task back

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -8,12 +8,20 @@ jobs:
     permissions:
       contents: write
     continue-on-error: true
-    steps:          
+    steps:     
+      - name: Authenticate with GitHub App
+        id: auth
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TERRAFORM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.TERRAFORM_AUTOMATION_PRIVATE_KEY }}     
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
           
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
Jira issue link: [FENG-759](https://workleap.atlassian.net/browse/FENG-759)

This pull request updates the GitHub Actions workflow for Terraform to improve security and streamline authentication. The main change involves adding steps to authenticate using a GitHub App token.

### Workflow improvements:

* [`.github/workflows/terraform-on-branch-push.yml`](diffhunk://#diff-f99d7c5102c3226875e2e3efd95b30ff80e52179221bf1d81d8d94d14eb726e4R12-R24): Added a step to authenticate with a GitHub App using the `actions/create-github-app-token@v2` action, which generates a token based on the app's ID and private key. The token is then used in the checkout step to enhance security.