### PR TITLE
Fix ENV variable for Terraform Cloud

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -56,7 +56,7 @@ jobs:
           LOG_FILE: renovate.log
           RENOVATE_TOKEN: ${{ steps.get_github_secret.outputs.secret }}
           LOG_LEVEL: "debug"
-          RENOVATE_TERRAFORM_MODULE_APP_TERRAFORM_IO_TOKEN: ${{ steps.get_terraform_secret.outputs.secret }}
+          RENOVATE_TERRAFORM__MODULE_APP_TERRAFORM_IO_TOKEN: ${{ steps.get_terraform_secret.outputs.secret }}
 
       # Ensure the output does not contain a line starting with "No repositories found"
       - name: Validate renovate output


### PR DESCRIPTION
Jira issue link: [FENG-708](https://workleap.atlassian.net/browse/FENG-708)

This pull request fixes a typo in the environment variable name within the `renovate.yml` workflow file to ensure proper functionality.

* Workflow configuration:
  * [`.github/workflows/renovate.yml`](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L59-R59): Corrected the environment variable name from `RENOVATE_TERRAFORM_MODULE_APP_TERRAFORM_IO_TOKEN` to `RENOVATE_TERRAFORM__MODULE_APP_TERRAFORM_IO_TOKEN` to match the expected format.

REF: https://docs.renovatebot.com/self-hosted-configuration/#detecthostrulesfromenv