### PR TITLE
Separate the Terraform tasks to improve flexibility

### DIFF
--- a/.github/workflows/terraform-auto-doc-check.yaml
+++ b/.github/workflows/terraform-auto-doc-check.yaml
@@ -32,7 +32,7 @@ jobs:
           author_name: github-actions[bot]
           author_email: github-actions[bot]@users.noreply.github.com
           default_author: github_actions
-          message: 'chore: apply formatting and docs update'
+          message: 'chore: update terraform documentation'
           push: true
           fetch: true
           pull: '--no-rebase'

--- a/.github/workflows/terraform-auto-doc-check.yaml
+++ b/.github/workflows/terraform-auto-doc-check.yaml
@@ -1,0 +1,38 @@
+name: Terraform Auto Documentation
+on: workflow_call
+
+jobs:
+  terraform-auto-doc:
+    name: Terraform auto documentation
+    runs-on: [idp]
+    permissions:
+      contents: write
+    continue-on-error: true
+    steps:     
+      - name: Authenticate with GitHub App
+        id: auth
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TERRAFORM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.TERRAFORM_AUTOMATION_PRIVATE_KEY }}     
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
+
+      - name: Terraform Docs
+        run: terraform-docs markdown table --output-file README.md --hide resources,data-sources .
+
+      - name: Commit file updates
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          author_name: github-actions[bot]
+          author_email: github-actions[bot]@users.noreply.github.com
+          default_author: github_actions
+          message: 'chore: apply formatting and docs update'
+          push: true
+          fetch: true
+          pull: '--no-rebase'

--- a/.github/workflows/terraform-linter-check.yaml
+++ b/.github/workflows/terraform-linter-check.yaml
@@ -1,0 +1,41 @@
+name: Terraform Linter Check
+on: workflow_call
+
+jobs:
+  tflint:
+    name: Terraform lint
+    runs-on: [idp]
+    steps:
+      - name: Authenticate with GitHub App
+        id: auth
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TERRAFORM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.TERRAFORM_AUTOMATION_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        name: Checkout source code
+        with:
+          token: ${{ steps.auth.outputs.token }}
+          
+      - uses: terraform-linters/tflint-load-config-action@v2
+        with:
+          source-repo: workleap/wl-reusable-workflows
+          source-path: /tflint/.tflint.hcl
+          source-ref: main
+          token: ${{ steps.auth.outputs.token }}
+          
+      - uses: terraform-linters/setup-tflint@v4
+        name: Setup TFLint
+        
+      - name: Show version
+        run: tflint --version
+        
+      - name: Init TFLint
+        run: tflint --init
+        env:
+          # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
+          
+      - name: Run TFLint
+        run: tflint -f compact

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -1,0 +1,77 @@
+name: Terraform standard checks
+on: workflow_call
+
+jobs:
+  terraform-common:
+    name: Terraform standard checks
+    runs-on: [idp]
+    permissions:
+      contents: write
+    continue-on-error: true
+    steps:     
+      - name: Authenticate with GitHub App
+        id: auth
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TERRAFORM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.TERRAFORM_AUTOMATION_PRIVATE_KEY }}   
+
+      - name: Get terraform cloud token
+        id: get_terraform_cloud_token
+        uses: workleap/wl-reusable-workflows/retrieve-managed-secret@main
+        with:
+          azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          keyvault-name: ${{ vars.IDP_CICD_KEYVAULT_NAME }}
+          secret-name: "renovate-tfc-token"            
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
+          
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        
+      - name: Terraform Format
+        run: terraform fmt -recursive
+
+      - name: Validate Terraform Code
+        id: terraform-validate
+        shell: pwsh
+        env:
+          TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
+        run: |
+          terraform init
+          terraform validate
+        
+      - name: Check for tests directory and .tftest.hcl files
+        id: check-tests
+        shell: pwsh
+        env:
+          TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
+        run: |
+          $testsExist = Test-Path -Path "./tests" -PathType Container
+          $testFiles = if ($testsExist) { Get-ChildItem -Path "./tests" -Filter "*.tftest.hcl" -Recurse } else { @() }
+          
+          if ($testsExist -and $testFiles.Count -gt 0) {
+            cd "./tests"
+            terraform init
+            terraform test
+          } else {
+            Write-Output "No unit tests found. Skipping test execution."
+          }
+
+      - name: Commit file updates
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          author_name: github-actions[bot]
+          author_email: github-actions[bot]@users.noreply.github.com
+          default_author: github_actions
+          message: 'chore: apply formatting update'
+          push: true
+          fetch: true
+          pull: '--no-rebase'

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -58,9 +58,14 @@ jobs:
           $testFiles = if ($testsExist) { Get-ChildItem -Path "./tests" -Filter "*.tftest.hcl" -Recurse } else { @() }
           
           if ($testsExist -and $testFiles.Count -gt 0) {
-            cd "./tests"
-            terraform init
-            terraform test
+            try {
+              Set-Location -Path "./tests"
+              terraform init
+              terraform test
+            } catch {
+              Write-Error "Failed to change directory to './tests'. Error: $_"
+              exit 1
+            }
           } else {
             Write-Output "No unit tests found. Skipping test execution."
           }


### PR DESCRIPTION
Jira issue link: [FENG-801](https://workleap.atlassian.net/browse/FENG-801)

This pull request introduces three new GitHub Actions workflows to automate various Terraform-related tasks, including documentation updates, linting, and standard checks. These workflows aim to streamline Terraform operations, enforce best practices, and ensure code quality.

### New Workflows for Terraform Automation:

#### Terraform Documentation Automation:
* Added `.github/workflows/terraform-auto-doc-check.yaml` to automate the generation and update of Terraform documentation using `terraform-docs`. The workflow commits updates to the `README.md` file.

#### Terraform Linter Integration:
* Added `.github/workflows/terraform-linter-check.yaml` to perform linting on Terraform code using TFLint. This includes setting up TFLint, loading configurations, and running lint checks with compact output formatting.

#### Standard Terraform Checks:
* Added `.github/workflows/terraform-standard-checks.yaml` to validate Terraform code, apply formatting, and execute unit tests if test files are present. The workflow retrieves a Terraform Cloud token for validation and testing purposes.

[FENG-801]: https://workleap.atlassian.net/browse/FENG-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ