### PR TITLE
Add permission

### DIFF
--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: [idp]
     permissions:
       contents: write
-    continue-on-error: true
+      id-token: write
     steps:     
       - name: Authenticate with GitHub App
         id: auth


### PR DESCRIPTION
Jira issue link: [FENG-801](https://workleap.atlassian.net/browse/FENG-801)

This pull request includes a minor update to the `.github/workflows/terraform-standard-checks.yaml` file. The change adjusts permissions by replacing `continue-on-error: true` with `id-token: write` under the `jobs:` configuration.

[FENG-801]: https://workleap.atlassian.net/browse/FENG-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ