### PR TITLE
Set workflow to run in each modified folders instead of only root

### DIFF
--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -98,7 +98,7 @@ jobs:
             $terraformDirs = @()
           }
           
-          if ($terraformDirs.Count -eq 0) {
+          if (@($terraformDirs).Count -eq 0) {
             Write-Output "No Terraform directories with changes found. Skipping validation."
             exit 0
           }
@@ -131,7 +131,7 @@ jobs:
             $terraformDirs = @()
           }
           
-          if ($terraformDirs.Count -eq 0) {
+          if (@($terraformDirs).Count -eq 0) {
             Write-Output "No Terraform directories with changes found. Skipping tests."
             exit 0
           }

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -32,6 +32,52 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           fetch-depth: 0
           token: ${{ steps.auth.outputs.token }}
+
+      - name: Get changed Terraform directories
+        id: get-changed-dirs
+        shell: pwsh
+        run: |
+          # Get list of changed files
+          if ("${{ github.event_name }}" -eq "pull_request") {
+            $changedFiles = git diff --name-only origin/${{ github.base_ref }}..HEAD
+          } else {
+            $changedFiles = git diff --name-only HEAD~1..HEAD
+          }
+          
+          # Find directories containing .tf files that have changes
+          $terraformDirs = @()
+          foreach ($file in $changedFiles) {
+            $dir = Split-Path -Parent $file
+            if ($dir -eq "") { $dir = "." }
+            
+            # Check if this directory or its parent contains .tf files
+            $currentDir = $dir
+            
+            # First check the current directory (including root ".")
+            if (Get-ChildItem -Path $currentDir -Filter "*.tf" -ErrorAction SilentlyContinue) {
+              if ($terraformDirs -notcontains $currentDir) {
+                $terraformDirs += $currentDir
+              }
+            } else {
+              # If current directory doesn't have .tf files, check parent directories
+              while ($currentDir -ne "" -and $currentDir -ne ".") {
+                $currentDir = Split-Path -Parent $currentDir
+                if ($currentDir -eq "") { $currentDir = "." }
+                
+                if (Get-ChildItem -Path $currentDir -Filter "*.tf" -ErrorAction SilentlyContinue) {
+                  if ($terraformDirs -notcontains $currentDir) {
+                    $terraformDirs += $currentDir
+                  }
+                  break
+                }
+              }
+            }
+          }
+          
+          # Output the directories as a JSON array
+          $dirsJson = $terraformDirs | ConvertTo-Json -Compress
+          Write-Output "terraform-dirs=$dirsJson" >> $env:GITHUB_OUTPUT
+          Write-Output "Changed Terraform directories: $dirsJson"
           
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -45,8 +91,27 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
-          terraform init
-          terraform validate
+          $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
+          
+          if ($terraformDirs.Count -eq 0) {
+            Write-Output "No Terraform directories with changes found. Skipping validation."
+            exit 0
+          }
+          
+          foreach ($dir in $terraformDirs) {
+            Write-Output "Validating Terraform in directory: $dir"
+            Push-Location $dir
+            try {
+              terraform init
+              terraform validate
+              Write-Output "✅ Validation successful for $dir"
+            } catch {
+              Write-Error "❌ Validation failed for $dir. Error: $_"
+              Pop-Location
+              exit 1
+            }
+            Pop-Location
+          }
         
       - name: Check for tests directory and .tftest.hcl files
         id: check-tests
@@ -54,20 +119,34 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
-          $testsExist = Test-Path -Path "./tests" -PathType Container
-          $testFiles = if ($testsExist) { Get-ChildItem -Path "./tests" -Filter "*.tftest.hcl" -Recurse } else { @() }
+          $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
           
-          if ($testsExist -and $testFiles.Count -gt 0) {
-            try {
-              Set-Location -Path "./tests"
-              terraform init
-              terraform test
-            } catch {
-              Write-Error "Failed to change directory to './tests'. Error: $_"
-              exit 1
+          if ($terraformDirs.Count -eq 0) {
+            Write-Output "No Terraform directories with changes found. Skipping tests."
+            exit 0
+          }
+          
+          foreach ($dir in $terraformDirs) {
+            $testsPath = Join-Path $dir "tests"
+            $testsExist = Test-Path -Path $testsPath -PathType Container
+            $testFiles = if ($testsExist) { Get-ChildItem -Path $testsPath -Filter "*.tftest.hcl" -Recurse } else { @() }
+            
+            if ($testsExist -and $testFiles.Count -gt 0) {
+              Write-Output "Running tests for directory: $dir"
+              Push-Location $testsPath
+              try {
+                terraform init
+                terraform test
+                Write-Output "✅ Tests successful for $dir"
+              } catch {
+                Write-Error "❌ Tests failed for $dir. Error: $_"
+                Pop-Location
+                exit 1
+              }
+              Pop-Location
+            } else {
+              Write-Output "No unit tests found in $dir. Skipping test execution for this directory."
             }
-          } else {
-            Write-Output "No unit tests found. Skipping test execution."
           }
 
       - name: Commit file updates

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -91,7 +91,12 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
-          $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
+          try {
+            $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
+          } catch {
+            Write-Output "Invalid or empty JSON output for Terraform directories. Skipping validation."
+            $terraformDirs = @()
+          }
           
           if ($terraformDirs.Count -eq 0) {
             Write-Output "No Terraform directories with changes found. Skipping validation."

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -124,7 +124,12 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
-          $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
+          $try {
+            $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
+          } catch {
+            Write-Output "Invalid or empty JSON output for Terraform directories. Skipping validation."
+            $terraformDirs = @()
+          }
           
           if ($terraformDirs.Count -eq 0) {
             Write-Output "No Terraform directories with changes found. Skipping tests."

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -124,7 +124,7 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ steps.get_terraform_cloud_token.outputs.secret }}
         run: |
-          $try {
+          try {
             $terraformDirs = '${{ steps.get-changed-dirs.outputs.terraform-dirs }}' | ConvertFrom-Json
           } catch {
             Write-Output "Invalid or empty JSON output for Terraform directories. Skipping validation."

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -75,7 +75,7 @@ jobs:
           }
           
           # Output the directories as a JSON array
-          $dirsJson = $terraformDirs | ConvertTo-Json -Compress
+          $dirsJson = $terraformDirs | ConvertTo-Json -Compress -AsArray
           Write-Output "terraform-dirs=$dirsJson" >> $env:GITHUB_OUTPUT
           Write-Output "Changed Terraform directories: $dirsJson"
           


### PR DESCRIPTION
Jira issue link: [FENG-810](https://workleap.atlassian.net/browse/FENG-810)

This pull request introduces enhancements to the Terraform validation and testing workflows in `.github/workflows/terraform-standard-checks.yaml`. The changes ensure that only directories containing modified Terraform files are processed, optimizing the workflow by skipping unnecessary validations and tests. Key improvements include dynamically identifying changed directories and iterating over them for validation and testing.

### Workflow Enhancements:

#### Dynamic Directory Detection:
* Added a step to identify directories containing changed `.tf` files and output them as a JSON array (`terraform-dirs`). This ensures that only relevant directories are processed in subsequent steps.

#### Optimized Terraform Validation:
* Modified the validation step to iterate over the detected directories, initializing and validating Terraform configurations in each. Skips validation if no relevant directories are found.

#### Targeted Test Execution:
* Updated the test execution step to run unit tests (`terraform test`) only in directories containing `.tftest.hcl` files within a `tests` subdirectory. Skips test execution for directories without test files.

[FENG-810]: https://workleap.atlassian.net/browse/FENG-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ