### PR TITLE
FENG-574 - Improve readme for nuget auth step

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
 ```
 
 ## Azure Artifacts Authenticate
-Before using this action, make sure the managed identity associated to your repository has access to the ADO feed.
+Before using this action, make sure the managed identity associated with your repository has access to the ADO feed.
 - Your managed identity will need to be a user of your Organization with the `Stakeholder` access level
 - Then this user will need to have either contributor or reader access to your ADO feed
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ jobs:
 ```
 
 ## Azure Artifacts Authenticate
+Before using this action, make sure the managed identity associated to your repository has access to the ADO feed.
+- Your managed identity will need to be a user of your Organization with the `Stakeholder` access level
+- Then this user will need to have either contributor or reader access to your ADO feed
 
 This action authenticates to Azure Artifacts feed using Azure CLI and configures the environment for package access. It sets up the necessary authentication tokens and credential providers for accessing Azure DevOps feeds.
 


### PR DESCRIPTION
Jira issue link: [feng-574](https://workleap.atlassian.net/browse/feng-574)

This pull request updates the `README.md` file to clarify the prerequisites for using the Azure Artifacts Authenticate action. It emphasizes the need for proper permissions for the managed identity associated with the repository.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R70): Added details about the required permissions for the managed identity, specifying that it must have `Stakeholder` access level in the organization and either contributor or reader access to the Azure DevOps feed.