### PR TITLE
Adding the possibility to specify indivually the Azure authentication parameters in the ADO feed action

### DIFF
--- a/az-artifact-authenticate/action.yml
+++ b/az-artifact-authenticate/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'The URL of the Azure Artifacts feed'
     required: true
   variables:
-    description: "Repository variables in JSON format (variables: '\\$\\{\\{ toJSON(vars) \\}\\}'). If ran through a Copilot coding agent, use the individual Azure authentication parameters instead."
+    description: "Repository variables in JSON format (variables: '\\$\\{\\{ toJSON(vars) \\}\\}'). If run through a Copilot coding agent, use the individual Azure authentication parameters instead."
     required: false
   client-id:
     description: "Client ID for Azure authentication"
@@ -19,9 +19,6 @@ inputs:
     required: false
   nuget-config-path:
     description: "Path to the NuGet configuration file (optional)"
-    required: false
-  global-json-path:
-    description: "Path to the global.json file (optional)"
     required: false
 
 runs:  
@@ -55,7 +52,6 @@ runs:
       with:
         source-url: ${{ inputs.feed-url }}
         config-file: ${{ inputs.nuget-config-path }}
-        global-json-file: ${{ inputs.global-json-path }}
       env:
         NUGET_AUTH_TOKEN: "unused-auth-token"
 


### PR DESCRIPTION
Jira issue link: [SGPD-3235](https://workleap.atlassian.net/browse/SGPD-3235)

While running the `az-artifact-authenticate` action in a Copilot coding agent, we noticed that the `toJSON(vars)` approach was always returning an empty value. While this was strange, we also noticed that the same exact code was working when ran outside of a Copilot coding agent. In both cases though, we are able to access individual variables from the `vars` object.

For this reason, this PR is to allow to specify individual parameters to the Action.

Example of a Copilot coding agent that is using these changes successfully: https://github.com/workleap/sg-insights/pull/1858/files

[SGPD-3235]: https://workleap.atlassian.net/browse/SGPD-3235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ