### PR TITLE
Set separator

### DIFF
--- a/.github/workflows/terraform-auto-doc-check.yaml
+++ b/.github/workflows/terraform-auto-doc-check.yaml
@@ -27,6 +27,7 @@ jobs:
         id: detect_tf
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
+          separator: "\n"
           files: |
             **/*.tf
             **/*.tfvars

--- a/.github/workflows/terraform-standard-checks.yaml
+++ b/.github/workflows/terraform-standard-checks.yaml
@@ -40,6 +40,7 @@ jobs:
         id: detect_tf
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
+          separator: "\n"
           files: |
             **/*.tf
             **/*.tfvars


### PR DESCRIPTION
Jira issue link: [FENG-894](https://workleap.atlassian.net/browse/FENG-894)

This pull request makes a minor update to the GitHub Actions workflows for Terraform checks. The change configures the `changed-files` action to use a newline character as the separator for its output, which can improve compatibility when processing lists of changed files.

* GitHub Actions configuration: Added `separator: "\n"` to the `detect_tf` step in both `.github/workflows/terraform-auto-doc-check.yaml` and `.github/workflows/terraform-standard-checks.yaml` to ensure changed files are separated by newlines. [[1]](diffhunk://#diff-38c06e5858a805eb0a3aca5438681a8d9f16084f50ea923988b1e6caa0d0cfa4R30) [[2]](diffhunk://#diff-f88c446f77e8b2d221809a4e022ec866be423a9539b25eacaa23cf9b52a57bf7R43)

[FENG-894]: https://workleap.atlassian.net/browse/FENG-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ