### PR TITLE
SGPD-3684: Update the branch pattern and corresponding group for Jira workflow

### DIFF
--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -12,7 +12,7 @@ on:
         default: ${{ github.head_ref || github.ref_name }}
 
 env:
-  BranchPattern: (?<=^|\/)[a-zA-Z][a-zA-Z0-9]*[_-][0-9]+
+  BranchPattern: .*(?:^|[^A-Za-z0-9])([A-Za-z][A-Za-z0-9]+-\d+)(?:[^A-Za-z0-9].*)?
 
 jobs:
   main:
@@ -69,7 +69,7 @@ jobs:
               throw "Branch name '$env:BranchName' doesn't respect the required pattern $env:BranchPattern. A valid branch name example would be: feature/PRJ-123"
             }
 
-            $JiraIssueKey = $Matches[0]
+            $JiraIssueKey = $Matches[1]
             $PWord = ConvertTo-SecureString -String "${{ steps.get_jira_api_secret.outputs.secret }}" -AsPlainText -Force
             $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "${{ steps.get_jira_username_secret.outputs.secret }}", $PWord
 
@@ -94,7 +94,7 @@ jobs:
 
         # Not all valid branch names will match the pattern (e.g. renovate branches)
         if("$env:BranchName" -match $env:BranchPattern) {
-          $jiraIssue = $Matches[0]
+          $jiraIssue = $Matches[1]
 
           $jiraLinkUrl = "https://workleap.atlassian.net/browse/$jiraIssue"
           $jiraLinkDescription = "Jira issue link: [$jiraIssue]($jiraLinkUrl)"


### PR DESCRIPTION
Currently, when opening a revert PR through GitHub the branch is automatically created with the prefix “revert-{some numbers}-” then followed by the original branch name. 

Our current branch pattern doesn’t expect to find a preceding word-number pattern unless that’s the Jira ticket itself which is causing these branches to fail and have to be recreated using the CLI.

Tested this change using Regex101 with the following cases:

SGPD-123_something:
<img width="1771" height="730" alt="image" src="https://github.com/user-attachments/assets/dcc3e294-8fa6-42a5-b72f-4d44a61de528" />

feature/ABC-123: 
<img width="2062" height="802" alt="image" src="https://github.com/user-attachments/assets/2a169297-1dee-4067-b80d-9e496905e56d" />

revert-456-feature-GHI-789:
<img width="2072" height="892" alt="image" src="https://github.com/user-attachments/assets/871d92b9-9e61-416e-8d86-ce5516340cd0" />

revert-123-feature/sub/JKL-012:
<img width="2082" height="636" alt="image" src="https://github.com/user-attachments/assets/5e2ea848-ec3f-40b1-82ba-504d84dcc1ed" />

revert-123-feature/sub/JKL-012_more_branch_naming:
<img width="2071" height="683" alt="image" src="https://github.com/user-attachments/assets/2e8b756a-a30b-4cd1-a898-e8f4ec2bae2d" />

revert-1970-SGPD-3662_swallow_job_errors:
<img width="1667" height="556" alt="image" src="https://github.com/user-attachments/assets/f299d7fe-764e-47d0-a49b-6038ce522d2c" />
