### PR TITLE
FENG-978 Bypass jira validation for copilot branches

### DIFF
--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -68,6 +68,12 @@ jobs:
               Write-Host "Skipping, renovate branch detected"
               return
             }
+            
+            if ("$env:BranchName" -like "copilot/fix-*" -eq $True)
+            {
+              Write-Host "Skipping, copilot fix branch detected"
+              return
+            }
 
             Set-JiraConfigServer -Server "${{ vars.JIRA_URL }}"
             if("$env:JiraMatches" -eq "false")


### PR DESCRIPTION
Jira issue link: [feng-978](https://workleap.atlassian.net/browse/feng-978)

This pull request introduces a conditional check in the `.github/workflows/reusable-jira-workflow.yml` workflow to skip certain steps if the branch name matches the pattern for copilot fix branches. This helps prevent unnecessary Jira integration steps for automated or fix branches.

Workflow improvements:

* Added a check to skip further steps in the workflow if the branch name matches the `copilot/fix-*` pattern, preventing Jira actions on these branches.