### PR TITLE
FENG-747 - Enable access to ADO feeds

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,18 @@
     }
   ],
   "packageRules": [
-      {
-      "matchDatasources": ["terraform-provider"],
+    {
+      "matchDatasources": [
+        "terraform-provider"
+      ],
       "registryUrls": [
         "https://registry.terraform.io"
       ]
     },
     {
-      "matchDatasources": ["terraform-module"],
+      "matchDatasources": [
+        "terraform-module"
+      ],
       "registryUrls": [
         "https://app.terraform.io/app/Workleap/registry/private/modules"
       ]
@@ -33,7 +37,6 @@
     "github>workleap/renovate-config:terraform-module.json",
     "github>workleap/renovate-config:terraform-provider.json"
   ],
-  "allowCommandTemplating": true,
   "allowedCommands": [
     "^terraform-docs markdown table --output-file README\\.md --hide resources,data-sources \\.\/?$"
   ]


### PR DESCRIPTION
Jira issue link: [feng-747](https://workleap.atlassian.net/browse/feng-747)

# Description
This pull request updates the `.github/workflows/reusable-renovate-workflow.yml` workflow to enable the integration with Azure DevOps feeds.

**Secret management and Renovate configuration:**

* Added a new step to retrieve the `renovate-ado-feeds-package-read` secret from Azure Key Vault using the reusable workflow `retrieve-managed-secret`, ensuring secure access to the required credentials.
* Updated the `RENOVATE_HOST_RULES` environment variable to include NuGet host authentication for Azure DevOps feeds, using the newly retrieved secret for the password. This enables Renovate to access and update packages from private Azure DevOps NuGet feeds.

# Additional checks
Create a test repo to make sure the changes worked as expected https://github.com/workleap/wl-test-caya-config.
Renovate was able to update packages from the `gsoft` feed from ADO and create PRs
<img width="1242" height="447" alt="image" src="https://github.com/user-attachments/assets/ffbf7f07-0ba6-435e-837a-b0d38d860f01" />

Tested that feed urls defined in `nuget.config` are used by renovate to lookup packages as we can see in this log:
```
2025-09-15T17:28:13.7366564Z DEBUG: Found NuGet.config at nuget.config (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7386334Z DEBUG: clearing registry URLs (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7388389Z DEBUG: Adding registry URL https://api.nuget.org/v3/index.json (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7388858Z        "registryUrl": "https://api.nuget.org/v3/index.json",
2025-09-15T17:28:13.7389153Z        "sourceMappedPackagePatterns": undefined
2025-09-15T17:28:13.7389729Z DEBUG: Adding registry URL https://pkgs.dev.azure.com/sharegate/_packaging/ShareGate/nuget/v3/index.json (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7390528Z        "registryUrl": "https://pkgs.dev.azure.com/sharegate/_packaging/ShareGate/nuget/v3/index.json",
2025-09-15T17:28:13.7390888Z        "sourceMappedPackagePatterns": undefined
2025-09-15T17:28:13.7391427Z DEBUG: Adding registry URL https://pkgs.dev.azure.com/workleap/_packaging/workleap/nuget/v3/index.json (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7391993Z        "registryUrl": "https://pkgs.dev.azure.com/workleap/_packaging/workleap/nuget/v3/index.json",
2025-09-15T17:28:13.7392340Z        "sourceMappedPackagePatterns": undefined
2025-09-15T17:28:13.7407477Z DEBUG: Found NuGet.config at nuget.config (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7412739Z DEBUG: clearing registry URLs (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7413561Z DEBUG: Adding registry URL https://api.nuget.org/v3/index.json (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7413963Z        "registryUrl": "https://api.nuget.org/v3/index.json",
2025-09-15T17:28:13.7414250Z        "sourceMappedPackagePatterns": undefined
2025-09-15T17:28:13.7414947Z DEBUG: Adding registry URL https://pkgs.dev.azure.com/sharegate/_packaging/ShareGate/nuget/v3/index.json (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7415596Z        "registryUrl": "https://pkgs.dev.azure.com/sharegate/_packaging/ShareGate/nuget/v3/index.json",
2025-09-15T17:28:13.7415949Z        "sourceMappedPackagePatterns": undefined
2025-09-15T17:28:13.7416497Z DEBUG: Adding registry URL https://pkgs.dev.azure.com/workleap/_packaging/workleap/nuget/v3/index.json (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7417069Z        "registryUrl": "https://pkgs.dev.azure.com/workleap/_packaging/workleap/nuget/v3/index.json",
2025-09-15T17:28:13.7417417Z        "sourceMappedPackagePatterns": undefined
2025-09-15T17:28:13.7421947Z DEBUG: manager extract durations (ms) (repository=workleap/wl-test-caya-config)
2025-09-15T17:28:13.7422470Z        "managers": {"github-actions": 12, "nuget": 17}
```

This way people don't need to manually define feed urls in their renovate config file.
