### PR TITLE
Add fallback Jira issue extraction from PR description

### DIFF
--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -94,7 +94,7 @@ jobs:
 
         Write-Host "Branch name did not match Jira pattern. Searching PR #$prNumber description for Jira issue..."
 
-        $prBody = gh pr view $prNumber --json body --jq '.body'
+        $prBody = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body'
 
         if (-not $prBody) {
           Write-Host "PR description is empty. No Jira issue found."
@@ -278,13 +278,13 @@ jobs:
           $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
           $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 
-          $prBody = gh pr view $prNumber --json body --jq '.body'
+          $prBody = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body'
 
           if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
             Write-Host 'JIRA link already present in pull request description'
           } else {
             $newBody = "$jiraLinkDescription`n`n$prBody"
-            gh pr edit $prNumber --body $newBody
+            gh pr edit $prNumber --repo "${{ github.repository }}" --body $newBody
             Write-Host 'Successfully added JIRA link to pull request description'
           }
         } else {

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -273,6 +273,10 @@ jobs:
         $prBodyLines = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
         $prBody = ($prBodyLines -join "`n")
 
+        # Remove any existing Jira issue link line so we can ensure it's always at the top
+        $escapedDescription = [regex]::Escape($jiraLinkDescription)
+        $prBody = ($prBody -replace "(?m)^\s*$escapedDescription\s*(\r?\n){0,2}", "").TrimStart("`r`n")
+
         $newBody = "$jiraLinkDescription`n`n$prBody"
         $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
-        Write-Host 'Successfully added JIRA link to pull request description'
+        Write-Host 'Successfully ensured JIRA link is at the top of pull request description'

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -266,6 +266,7 @@ jobs:
         PR_NUMBER: "${{ github.event.pull_request.number }}"
         JiraIssue: "${{ steps.check_jira.outputs.jira_issue }}"
       run: |
+        Write-Host "hello world"
         $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
         $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -94,7 +94,7 @@ jobs:
 
         Write-Host "Branch name did not match Jira pattern. Searching PR #$prNumber description for Jira issue..."
 
-        $prBody = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body'
+        $prBody = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body // ""'
 
         if (-not $prBody) {
           Write-Host "PR description is empty. No Jira issue found."
@@ -146,9 +146,12 @@ jobs:
         if ($env:BRANCH_MATCHES -eq "true") {
           $resolvedMatches = $env:BRANCH_MATCHES
           $resolvedKeys = $env:BRANCH_KEYS
-        } else {
+        } elseif ($env:FALLBACK_MATCHES) {
           $resolvedMatches = $env:FALLBACK_MATCHES
           $resolvedKeys = $env:FALLBACK_KEYS
+        } else {
+          $resolvedMatches = "false"
+          $resolvedKeys = "[]"
         }
 
         Write-Host "Resolved matches=$resolvedMatches, keys=$resolvedKeys"
@@ -266,7 +269,7 @@ jobs:
         $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
         $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 
-        $prBody = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body'
+        $prBody = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
 
         if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
           Write-Host 'JIRA link already present in pull request description'

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -78,33 +78,30 @@ jobs:
         "branch_name=$BranchName" >> $env:GITHUB_OUTPUT
 
     - name: Extract Jira Issue from branch name
-      id: extract_jira
+      id: extract_jira_branch
       uses: workleap/wl-reusable-workflows/extract-jira-issue@main
       with:
         branch_name: ${{ steps.branch_name.outputs.branch_name }}
 
-    - name: Fallback - Extract Jira Issue from PR description
-      id: extract_jira_fallback
-      if: steps.extract_jira.outputs.matches == 'false' && github.event.pull_request.number
+    - name: Extract Jira Issue from PR description
+      id: extract_jira_pr
+      if: github.event.pull_request.number
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         $prNumber = "${{ github.event.pull_request.number }}"
 
-        Write-Host "Branch name did not match Jira pattern. Searching PR #$prNumber description for Jira issue..."
+        Write-Host "Searching PR #$prNumber description for Jira issues..."
 
         $prBodyLines = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body // ""'
         $prBody = ($prBodyLines -join "`n")
 
         if (-not $prBody) {
           Write-Host "PR description is empty. No Jira issue found."
-          "matches=false" >> $env:GITHUB_OUTPUT
           "jira_issue_matches=[]" >> $env:GITHUB_OUTPUT
           exit 0
         }
-
-        Write-Host "PR description found. Searching for Jira issues..."
 
         # Match Jira URLs like https://workleap.atlassian.net/browse/PRJ-123
         $urlPattern = 'https?://[a-zA-Z0-9.-]+\.atlassian\.net/browse/([A-Za-z][A-Za-z0-9]+-\d+)'
@@ -127,46 +124,50 @@ jobs:
         if ($issueKeys.Count -gt 0) {
           $jsonKeys = @($issueKeys) | ConvertTo-Json -Compress -AsArray
           Write-Host "Found Jira issue(s) in PR description: $jsonKeys"
-          "matches=true" >> $env:GITHUB_OUTPUT
           "jira_issue_matches=$jsonKeys" >> $env:GITHUB_OUTPUT
         } else {
           Write-Host "No Jira issue found in PR description."
-          "matches=false" >> $env:GITHUB_OUTPUT
           "jira_issue_matches=[]" >> $env:GITHUB_OUTPUT
         }
 
-    - name: Resolve Jira extraction results
-      id: resolved_jira
+    - name: Combine Jira extraction results
+      id: combined_jira
       shell: pwsh
       env:
-        BRANCH_MATCHES: "${{ steps.extract_jira.outputs.matches }}"
-        BRANCH_KEYS: "${{ steps.extract_jira.outputs.jira_issue_matches }}"
-        FALLBACK_MATCHES: "${{ steps.extract_jira_fallback.outputs.matches }}"
-        FALLBACK_KEYS: "${{ steps.extract_jira_fallback.outputs.jira_issue_matches }}"
+        BRANCH_KEYS: "${{ steps.extract_jira_branch.outputs.jira_issue_matches }}"
+        PR_KEYS: "${{ steps.extract_jira_pr.outputs.jira_issue_matches || '[]' }}"
       run: |
-        if ($env:BRANCH_MATCHES -eq "true") {
-          $resolvedMatches = $env:BRANCH_MATCHES
-          $resolvedKeys = $env:BRANCH_KEYS
-        } elseif ($env:FALLBACK_MATCHES) {
-          $resolvedMatches = $env:FALLBACK_MATCHES
-          $resolvedKeys = $env:FALLBACK_KEYS
-        } else {
-          $resolvedMatches = "false"
-          $resolvedKeys = "[]"
+        $branchKeys = if ($env:BRANCH_KEYS) { $env:BRANCH_KEYS | ConvertFrom-Json } else { @() }
+        $prKeys = if ($env:PR_KEYS) { $env:PR_KEYS | ConvertFrom-Json } else { @() }
+
+        # Combine both sources: branch keys first, then PR description keys, deduplicated
+        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $combinedKeys = [System.Collections.Generic.List[string]]::new()
+        foreach ($key in $branchKeys) {
+          if ($seen.Add($key)) { $combinedKeys.Add($key) }
+        }
+        foreach ($key in $prKeys) {
+          if ($seen.Add($key)) { $combinedKeys.Add($key) }
         }
 
-        Write-Host "Resolved matches=$resolvedMatches, keys=$resolvedKeys"
-        "matches=$resolvedMatches" >> $env:GITHUB_OUTPUT
-        "jira_issue_matches=$resolvedKeys" >> $env:GITHUB_OUTPUT
+        $hasMatches = $combinedKeys.Count -gt 0
+        $jsonKeys = @($combinedKeys) | ConvertTo-Json -Compress -AsArray
+
+        Write-Host "Branch keys: $env:BRANCH_KEYS"
+        Write-Host "PR description keys: $env:PR_KEYS"
+        Write-Host "Combined keys: $jsonKeys (matches: $hasMatches)"
+
+        "matches=$($hasMatches.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+        "jira_issue_matches=$jsonKeys" >> $env:GITHUB_OUTPUT
 
     - name: Check Jira Story
       id: check_jira
       shell: pwsh
       env:
         BranchName: "${{ steps.branch_name.outputs.branch_name }}"
-        BranchPattern: "${{ steps.extract_jira.outputs.pattern }}"
-        JiraMatches: "${{ steps.resolved_jira.outputs.matches }}"
-        JiraIssueKeys: "${{ steps.resolved_jira.outputs.jira_issue_matches }}"
+        BranchPattern: "${{ steps.extract_jira_branch.outputs.pattern }}"
+        JiraMatches: "${{ steps.combined_jira.outputs.matches }}"
+        JiraIssueKeys: "${{ steps.combined_jira.outputs.jira_issue_matches }}"
       run: |
         # Check if JiraPS module is already available
         $jiraPSModule = Get-Module -ListAvailable -Name JiraPS
@@ -260,7 +261,7 @@ jobs:
         }
 
     - name: Add Jira issue link
-      if: steps.resolved_jira.outputs.matches == 'true' && github.event.pull_request.number && inputs.is_CI != true
+      if: steps.check_jira.outputs.jira_issue && github.event.pull_request.number && inputs.is_CI != true
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
@@ -273,10 +274,10 @@ jobs:
         $prBodyLines = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
         $prBody = ($prBodyLines -join "`n")
 
-        if ($prBody.StartsWith($jiraLinkDescription)) {
-          Write-Host 'JIRA link already at the top of pull request description'
-        } else {
-          $newBody = "$jiraLinkDescription`n`n$prBody"
-          $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
-          Write-Host 'Successfully added JIRA link to the top of pull request description'
-        }
+        # Remove any existing Jira issue link line at the top (with optional trailing blank lines)
+        $jiraLinkPattern = '^Jira issue link: \[[A-Za-z][A-Za-z0-9]+-\d+\]\(https?://[^\)]+\)\s*(\r?\n){0,2}'
+        $prBody = [regex]::Replace($prBody, $jiraLinkPattern, '')
+
+        $newBody = "$jiraLinkDescription`n`n$prBody"
+        $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
+        Write-Host "Successfully ensured JIRA link is at the top of pull request description"

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -273,10 +273,6 @@ jobs:
         $prBodyLines = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
         $prBody = ($prBodyLines -join "`n")
 
-        if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
-          Write-Host 'JIRA link already present in pull request description'
-        } else {
-          $newBody = "$jiraLinkDescription`n`n$prBody"
-          $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
-          Write-Host 'Successfully added JIRA link to pull request description'
-        }
+        $newBody = "$jiraLinkDescription`n`n$prBody"
+        $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
+        Write-Host 'Successfully added JIRA link to pull request description'

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -127,7 +127,6 @@ jobs:
           Write-Host "Found Jira issue(s) in PR description: $jsonKeys"
           "matches=true" >> $env:GITHUB_OUTPUT
           "jira_issue_matches=$jsonKeys" >> $env:GITHUB_OUTPUT
-          "source=pr_description" >> $env:GITHUB_OUTPUT
         } else {
           Write-Host "No Jira issue found in PR description."
           "matches=false" >> $env:GITHUB_OUTPUT
@@ -142,7 +141,6 @@ jobs:
         BranchPattern: "${{steps.extract_jira.outputs.pattern}}"
         JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
         JiraIssueKeys: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.jira_issue_matches || steps.extract_jira_fallback.outputs.jira_issue_matches }}"
-        JiraSource: "${{ steps.extract_jira.outputs.matches == 'true' && 'branch_name' || steps.extract_jira_fallback.outputs.source }}"
       run: |
         # Check if JiraPS module is already available
         $jiraPSModule = Get-Module -ListAvailable -Name JiraPS
@@ -195,18 +193,6 @@ jobs:
           return
         }
 
-        if ("$env:BranchName" -like "copilot/*" -eq $True)
-        {
-          Write-Host "Skipping, copilot branch detected"
-          return
-        }
-
-        if ("$env:BranchName" -like "claude/*" -eq $True)
-        {
-          Write-Host "Skipping, claude branch detected"
-          return
-        }
-
         if ("$env:BranchName" -like "gh-readonly-queue/*" -eq $True)
         {
           Write-Host "Skipping, GitHub merge queue branch detected"
@@ -255,7 +241,6 @@ jobs:
         BranchPattern: "${{ steps.extract_jira.outputs.pattern }}"
         JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
         JiraIssue: "${{ steps.check_jira.outputs.jira_issue }}"
-        JiraSource: "${{ steps.extract_jira.outputs.matches == 'true' && 'branch_name' || steps.extract_jira_fallback.outputs.source }}"
       run: |
 
         # We don't want the Jira link to come from the test workflow since we're using a fixed branch name
@@ -284,7 +269,7 @@ jobs:
             Write-Host 'JIRA link already present in pull request description'
           } else {
             $newBody = "$jiraLinkDescription`n`n$prBody"
-            gh pr edit $prNumber --repo "${{ github.repository }}" --body $newBody
+            $newBody | gh pr edit $prNumber --repo "${{ github.repository }}" --body-file -
             Write-Host 'Successfully added JIRA link to pull request description'
           }
         } else {

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -77,11 +77,70 @@ jobs:
         Write-Host "Branch name: $BranchName"
         "branch_name=$BranchName" >> $env:GITHUB_OUTPUT
 
-    - name: Extract Jira Issue
+    - name: Extract Jira Issue from branch name
       id: extract_jira
       uses: workleap/wl-reusable-workflows/extract-jira-issue@main
       with:
         branch_name: ${{ steps.branch_name.outputs.branch_name }}
+
+    - name: Fallback - Extract Jira Issue from PR description
+      id: extract_jira_fallback
+      if: steps.extract_jira.outputs.matches == 'false' && github.event.pull_request.number
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $repo = "${{ github.repository }}"
+        $prNumber = "${{ github.event.pull_request.number }}"
+
+        Write-Host "Branch name did not match Jira pattern. Searching PR #$prNumber description for Jira issue..."
+
+        $headers = @{
+          Authorization = "Bearer $env:GH_TOKEN"
+          "Accept" = "application/vnd.github.v3+json"
+        }
+
+        $prUrl = "https://api.github.com/repos/$repo/pulls/$prNumber"
+        $pr = Invoke-RestMethod -Uri $prUrl -Headers $headers
+
+        $prBody = $pr.body
+        if (-not $prBody) {
+          Write-Host "PR description is empty. No Jira issue found."
+          "matches=false" >> $env:GITHUB_OUTPUT
+          "jira_issue_matches=[]" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        Write-Host "PR description found. Searching for Jira issues..."
+
+        # Match Jira URLs like https://workleap.atlassian.net/browse/PRJ-123
+        $urlPattern = 'https?://[a-zA-Z0-9.-]+\.atlassian\.net/browse/([A-Za-z][A-Za-z0-9]+-\d+)'
+        $urlMatches = [regex]::Matches($prBody, $urlPattern)
+
+        # Also match standalone Jira issue keys like PRJ-123
+        $keyPattern = '\b(?!revert-\d+\b)([A-Za-z][A-Za-z0-9]+-\d+)\b'
+        $keyMatches = [regex]::Matches($prBody, $keyPattern)
+
+        # Collect unique issue keys, preferring URL matches first
+        $issueKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($m in $urlMatches) {
+          [void]$issueKeys.Add($m.Groups[1].Value)
+        }
+        foreach ($m in $keyMatches) {
+          [void]$issueKeys.Add($m.Groups[1].Value)
+        }
+
+        if ($issueKeys.Count -gt 0) {
+          $jsonKeys = @($issueKeys) | ConvertTo-Json -Compress -AsArray
+          Write-Host "Found Jira issue(s) in PR description: $jsonKeys"
+          "matches=true" >> $env:GITHUB_OUTPUT
+          "jira_issue_matches=$jsonKeys" >> $env:GITHUB_OUTPUT
+          "source=pr_description" >> $env:GITHUB_OUTPUT
+        } else {
+          Write-Host "No Jira issue found in PR description."
+          "matches=false" >> $env:GITHUB_OUTPUT
+          "jira_issue_matches=[]" >> $env:GITHUB_OUTPUT
+        }
 
     - name: Check Jira Story
       id: check_jira
@@ -89,8 +148,9 @@ jobs:
       env:
         BranchName: "${{steps.branch_name.outputs.branch_name}}"
         BranchPattern: "${{steps.extract_jira.outputs.pattern}}"
-        JiraMatches: "${{steps.extract_jira.outputs.matches}}"
-        JiraIssueKeys: "${{steps.extract_jira.outputs.jira_issue_matches}}"
+        JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
+        JiraIssueKeys: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.jira_issue_matches || steps.extract_jira_fallback.outputs.jira_issue_matches }}"
+        JiraSource: "${{ steps.extract_jira.outputs.matches == 'true' && 'branch_name' || steps.extract_jira_fallback.outputs.source }}"
       run: |
         # Check if JiraPS module is already available
         $jiraPSModule = Get-Module -ListAvailable -Name JiraPS
@@ -158,7 +218,7 @@ jobs:
         Set-JiraConfigServer -Server "${{ vars.JIRA_URL }}"
         if("$env:JiraMatches" -eq "false")
         {
-          throw "Branch name '$env:BranchName' doesn't respect the required pattern $env:BranchPattern. A valid branch name example would be: feature/PRJ-123"
+          throw "No Jira issue found. Branch name '$env:BranchName' doesn't match pattern $env:BranchPattern and no Jira issue was found in the PR description. Either use a branch name like feature/PRJ-123 or include a Jira issue key (e.g. PRJ-123) or link (e.g. https://workleap.atlassian.net/browse/PRJ-123) in the PR description."
         }
 
         $PWord = ConvertTo-SecureString -String "${{ steps.get_jira_api_secret.outputs.secret }}" -AsPlainText -Force
@@ -194,8 +254,9 @@ jobs:
       env:
         BranchName: "${{ steps.branch_name.outputs.branch_name }}"
         BranchPattern: "${{ steps.extract_jira.outputs.pattern }}"
-        JiraMatches: "${{ steps.extract_jira.outputs.matches }}"
+        JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
         JiraIssue: "${{ steps.check_jira.outputs.jira_issue }}"
+        JiraSource: "${{ steps.extract_jira.outputs.matches == 'true' && 'branch_name' || steps.extract_jira_fallback.outputs.source }}"
       run: |
 
         # We don't want the Jira link to come from the test workflow since we're using a fixed branch name

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -113,13 +113,14 @@ jobs:
         $keyPattern = '\b(?!revert-\d+\b)([A-Za-z][A-Za-z0-9]+-\d+)\b'
         $keyMatches = [regex]::Matches($prBody, $keyPattern)
 
-        # Collect unique issue keys, preferring URL matches first
-        $issueKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        # Collect unique issue keys in order: URL matches first, then standalone keys
+        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $issueKeys = [System.Collections.Generic.List[string]]::new()
         foreach ($m in $urlMatches) {
-          [void]$issueKeys.Add($m.Groups[1].Value)
+          if ($seen.Add($m.Groups[1].Value)) { $issueKeys.Add($m.Groups[1].Value) }
         }
         foreach ($m in $keyMatches) {
-          [void]$issueKeys.Add($m.Groups[1].Value)
+          if ($seen.Add($m.Groups[1].Value)) { $issueKeys.Add($m.Groups[1].Value) }
         }
 
         if ($issueKeys.Count -gt 0) {

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -133,14 +133,30 @@ jobs:
           "jira_issue_matches=[]" >> $env:GITHUB_OUTPUT
         }
 
+    - name: Resolve Jira extraction results
+      id: resolved_jira
+      shell: pwsh
+      run: |
+        $matches = "${{ steps.extract_jira.outputs.matches }}"
+        $issueKeys = "${{ steps.extract_jira.outputs.jira_issue_matches }}"
+
+        if ($matches -ne "true") {
+          $matches = "${{ steps.extract_jira_fallback.outputs.matches }}"
+          $issueKeys = "${{ steps.extract_jira_fallback.outputs.jira_issue_matches }}"
+        }
+
+        Write-Host "Resolved matches=$matches, keys=$issueKeys"
+        "matches=$matches" >> $env:GITHUB_OUTPUT
+        "jira_issue_matches=$issueKeys" >> $env:GITHUB_OUTPUT
+
     - name: Check Jira Story
       id: check_jira
       shell: pwsh
       env:
-        BranchName: "${{steps.branch_name.outputs.branch_name}}"
-        BranchPattern: "${{steps.extract_jira.outputs.pattern}}"
-        JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
-        JiraIssueKeys: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.jira_issue_matches || steps.extract_jira_fallback.outputs.jira_issue_matches }}"
+        BranchName: "${{ steps.branch_name.outputs.branch_name }}"
+        BranchPattern: "${{ steps.extract_jira.outputs.pattern }}"
+        JiraMatches: "${{ steps.resolved_jira.outputs.matches }}"
+        JiraIssueKeys: "${{ steps.resolved_jira.outputs.jira_issue_matches }}"
       run: |
         # Check if JiraPS module is already available
         $jiraPSModule = Get-Module -ListAvailable -Name JiraPS
@@ -234,44 +250,22 @@ jobs:
         }
 
     - name: Add Jira issue link
+      if: steps.resolved_jira.outputs.matches == 'true' && github.event.pull_request.number && inputs.is_CI != true
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
-        BranchName: "${{ steps.branch_name.outputs.branch_name }}"
-        BranchPattern: "${{ steps.extract_jira.outputs.pattern }}"
-        JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
+        PR_NUMBER: "${{ github.event.pull_request.number }}"
         JiraIssue: "${{ steps.check_jira.outputs.jira_issue }}"
       run: |
+        $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
+        $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 
-        # We don't want the Jira link to come from the test workflow since we're using a fixed branch name
-        if ("${{ inputs.is_CI }}" -eq $true) {
-          Write-Host 'Running in test mode, skipping adding Jira link to pull request description.'
-          exit 0
-        }
+        $prBody = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body'
 
-        if (-not "${{ github.event.pull_request.number }}") {
-          Write-Host 'No pull request context. Skipping adding Jira link to pull request description.'
-          exit 0
-        }
-
-        Write-Host 'Adding JIRA link to pull request description'
-
-        $prNumber = "${{ github.event.pull_request.number }}"
-
-        # Not all valid branch names will match the pattern (e.g. renovate branches)
-        if("$env:JiraMatches" -eq "true") {
-          $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
-          $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
-
-          $prBody = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body'
-
-          if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
-            Write-Host 'JIRA link already present in pull request description'
-          } else {
-            $newBody = "$jiraLinkDescription`n`n$prBody"
-            $newBody | gh pr edit $prNumber --repo "${{ github.repository }}" --body-file -
-            Write-Host 'Successfully added JIRA link to pull request description'
-          }
+        if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
+          Write-Host 'JIRA link already present in pull request description'
         } else {
-          Write-Host "Branch name '$env:BranchName' does not match the Jira pattern $env:BranchPattern. Skipping JIRA link insertion."
+          $newBody = "$jiraLinkDescription`n`n$prBody"
+          $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
+          Write-Host 'Successfully added JIRA link to pull request description'
         }

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -137,18 +137,23 @@ jobs:
     - name: Resolve Jira extraction results
       id: resolved_jira
       shell: pwsh
+      env:
+        BRANCH_MATCHES: "${{ steps.extract_jira.outputs.matches }}"
+        BRANCH_KEYS: "${{ steps.extract_jira.outputs.jira_issue_matches }}"
+        FALLBACK_MATCHES: "${{ steps.extract_jira_fallback.outputs.matches }}"
+        FALLBACK_KEYS: "${{ steps.extract_jira_fallback.outputs.jira_issue_matches }}"
       run: |
-        $matches = "${{ steps.extract_jira.outputs.matches }}"
-        $issueKeys = "${{ steps.extract_jira.outputs.jira_issue_matches }}"
-
-        if ($matches -ne "true") {
-          $matches = "${{ steps.extract_jira_fallback.outputs.matches }}"
-          $issueKeys = "${{ steps.extract_jira_fallback.outputs.jira_issue_matches }}"
+        if ($env:BRANCH_MATCHES -eq "true") {
+          $resolvedMatches = $env:BRANCH_MATCHES
+          $resolvedKeys = $env:BRANCH_KEYS
+        } else {
+          $resolvedMatches = $env:FALLBACK_MATCHES
+          $resolvedKeys = $env:FALLBACK_KEYS
         }
 
-        Write-Host "Resolved matches=$matches, keys=$issueKeys"
-        "matches=$matches" >> $env:GITHUB_OUTPUT
-        "jira_issue_matches=$issueKeys" >> $env:GITHUB_OUTPUT
+        Write-Host "Resolved matches=$resolvedMatches, keys=$resolvedKeys"
+        "matches=$resolvedMatches" >> $env:GITHUB_OUTPUT
+        "jira_issue_matches=$resolvedKeys" >> $env:GITHUB_OUTPUT
 
     - name: Check Jira Story
       id: check_jira

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -273,10 +273,10 @@ jobs:
         $prBodyLines = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
         $prBody = ($prBodyLines -join "`n")
 
-        # Remove any existing Jira issue link line so we can ensure it's always at the top
-        $escapedDescription = [regex]::Escape($jiraLinkDescription)
-        $prBody = ($prBody -replace "(?m)^\s*$escapedDescription\s*(\r?\n){0,2}", "").TrimStart("`r`n")
-
-        $newBody = "$jiraLinkDescription`n`n$prBody"
-        $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
-        Write-Host 'Successfully ensured JIRA link is at the top of pull request description'
+        if ($prBody.StartsWith($jiraLinkDescription)) {
+          Write-Host 'JIRA link already at the top of pull request description'
+        } else {
+          $newBody = "$jiraLinkDescription`n`n$prBody"
+          $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
+          Write-Host 'Successfully added JIRA link to the top of pull request description'
+        }

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -266,7 +266,6 @@ jobs:
         PR_NUMBER: "${{ github.event.pull_request.number }}"
         JiraIssue: "${{ steps.check_jira.outputs.jira_issue }}"
       run: |
-        Write-Host "hello world"
         $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
         $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -271,10 +271,6 @@ jobs:
 
         $prBody = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
 
-        if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
-          Write-Host 'JIRA link already present in pull request description'
-        } else {
-          $newBody = "$jiraLinkDescription`n`n$prBody"
-          $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
-          Write-Host 'Successfully added JIRA link to pull request description'
-        }
+        $newBody = "$jiraLinkDescription`n`n$prBody"
+        $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
+        Write-Host 'Successfully added JIRA link to pull request description'

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -94,7 +94,8 @@ jobs:
 
         Write-Host "Branch name did not match Jira pattern. Searching PR #$prNumber description for Jira issue..."
 
-        $prBody = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body // ""'
+        $prBodyLines = gh pr view $prNumber --repo "${{ github.repository }}" --json body --jq '.body // ""'
+        $prBody = ($prBodyLines -join "`n")
 
         if (-not $prBody) {
           Write-Host "PR description is empty. No Jira issue found."
@@ -269,8 +270,13 @@ jobs:
         $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
         $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 
-        $prBody = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
+        $prBodyLines = gh pr view $env:PR_NUMBER --repo "${{ github.repository }}" --json body --jq '.body // ""'
+        $prBody = ($prBodyLines -join "`n")
 
-        $newBody = "$jiraLinkDescription`n`n$prBody"
-        $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
-        Write-Host 'Successfully added JIRA link to pull request description'
+        if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
+          Write-Host 'JIRA link already present in pull request description'
+        } else {
+          $newBody = "$jiraLinkDescription`n`n$prBody"
+          $newBody | gh pr edit $env:PR_NUMBER --repo "${{ github.repository }}" --body-file -
+          Write-Host 'Successfully added JIRA link to pull request description'
+        }

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -112,13 +112,12 @@ jobs:
         $keyMatches = [regex]::Matches($prBody, $keyPattern)
 
         # Collect unique issue keys in order: URL matches first, then standalone keys
-        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-        $issueKeys = [System.Collections.Generic.List[string]]::new()
+        $issueKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         foreach ($m in $urlMatches) {
-          if ($seen.Add($m.Groups[1].Value)) { $issueKeys.Add($m.Groups[1].Value) }
+          [void]$issueKeys.Add($m.Groups[1].Value)
         }
         foreach ($m in $keyMatches) {
-          if ($seen.Add($m.Groups[1].Value)) { $issueKeys.Add($m.Groups[1].Value) }
+          [void]$issueKeys.Add($m.Groups[1].Value)
         }
 
         if ($issueKeys.Count -gt 0) {
@@ -141,13 +140,12 @@ jobs:
         $prKeys = if ($env:PR_KEYS) { $env:PR_KEYS | ConvertFrom-Json } else { @() }
 
         # Combine both sources: branch keys first, then PR description keys, deduplicated
-        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-        $combinedKeys = [System.Collections.Generic.List[string]]::new()
+        $combinedKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         foreach ($key in $branchKeys) {
-          if ($seen.Add($key)) { $combinedKeys.Add($key) }
+          [void]$combinedKeys.Add($key)
         }
         foreach ($key in $prKeys) {
-          if ($seen.Add($key)) { $combinedKeys.Add($key) }
+          [void]$combinedKeys.Add($key)
         }
 
         $hasMatches = $combinedKeys.Count -gt 0
@@ -157,7 +155,7 @@ jobs:
         Write-Host "PR description keys: $env:PR_KEYS"
         Write-Host "Combined keys: $jsonKeys (matches: $hasMatches)"
 
-        "matches=$($hasMatches.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+        "matches=$($hasMatches.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
         "jira_issue_matches=$jsonKeys" >> $env:GITHUB_OUTPUT
 
     - name: Check Jira Story

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -209,12 +209,6 @@ jobs:
           return
         }
 
-        if ("$env:BranchName" -like "copilot/*" -eq $True)
-        {
-          Write-Host "Skipping, copilot branch detected"
-          return
-        }
-
         if ("$env:BranchName" -like "gh-readonly-queue/*" -eq $True)
         {
           Write-Host "Skipping, GitHub merge queue branch detected"

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -209,6 +209,12 @@ jobs:
           return
         }
 
+        if ("$env:BranchName" -like "copilot/*" -eq $True)
+        {
+          Write-Host "Skipping, copilot branch detected"
+          return
+        }
+
         if ("$env:BranchName" -like "gh-readonly-queue/*" -eq $True)
         {
           Write-Host "Skipping, GitHub merge queue branch detected"

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -90,20 +90,12 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        $repo = "${{ github.repository }}"
         $prNumber = "${{ github.event.pull_request.number }}"
 
         Write-Host "Branch name did not match Jira pattern. Searching PR #$prNumber description for Jira issue..."
 
-        $headers = @{
-          Authorization = "Bearer $env:GH_TOKEN"
-          "Accept" = "application/vnd.github.v3+json"
-        }
+        $prBody = gh pr view $prNumber --json body --jq '.body'
 
-        $prUrl = "https://api.github.com/repos/$repo/pulls/$prNumber"
-        $pr = Invoke-RestMethod -Uri $prUrl -Headers $headers
-
-        $prBody = $pr.body
         if (-not $prBody) {
           Write-Host "PR description is empty. No Jira issue found."
           "matches=false" >> $env:GITHUB_OUTPUT
@@ -252,6 +244,7 @@ jobs:
     - name: Add Jira issue link
       shell: pwsh
       env:
+        GH_TOKEN: ${{ github.token }}
         BranchName: "${{ steps.branch_name.outputs.branch_name }}"
         BranchPattern: "${{ steps.extract_jira.outputs.pattern }}"
         JiraMatches: "${{ steps.extract_jira.outputs.matches == 'true' && steps.extract_jira.outputs.matches || steps.extract_jira_fallback.outputs.matches }}"
@@ -272,7 +265,6 @@ jobs:
 
         Write-Host 'Adding JIRA link to pull request description'
 
-        $repo = "${{ github.repository }}"
         $prNumber = "${{ github.event.pull_request.number }}"
 
         # Not all valid branch names will match the pattern (e.g. renovate branches)
@@ -280,27 +272,14 @@ jobs:
           $jiraLinkUrl = "https://workleap.atlassian.net/browse/$env:JiraIssue"
           $jiraLinkDescription = "Jira issue link: [$env:JiraIssue]($jiraLinkUrl)"
 
-          $token = "${{ github.token }}"
-          $headers = @{
-            Authorization = "Bearer $token"
-            "Accept" = "application/vnd.github.v3+json"
-          }
+          $prBody = gh pr view $prNumber --json body --jq '.body'
 
-          $prUrl = "https://api.github.com/repos/$repo/pulls/$prNumber"
-          $pr = Invoke-RestMethod -Uri $prUrl -Headers $headers
-
-          if ($null -ne $pr.body -and ($pr.body -match "$jiraLinkUrl")) {
-            $newBody = $pr.body
-          } else {
-            $newBody = "$jiraLinkDescription`n`n$($pr.body)"
-          }
-
-          if ($newBody -ne $pr.body) {
-            $body = @{ body = $newBody } | ConvertTo-Json
-            Invoke-RestMethod -Uri $prUrl -Headers $headers -Method Patch -Body $body
-            Write-Host 'Successfully added JIRA link to pull request description'
-          } else {
+          if ($prBody -match [regex]::Escape($jiraLinkUrl)) {
             Write-Host 'JIRA link already present in pull request description'
+          } else {
+            $newBody = "$jiraLinkDescription`n`n$prBody"
+            gh pr edit $prNumber --body $newBody
+            Write-Host 'Successfully added JIRA link to pull request description'
           }
         } else {
           Write-Host "Branch name '$env:BranchName' does not match the Jira pattern $env:BranchPattern. Skipping JIRA link insertion."


### PR DESCRIPTION
Jira issue link: [FENG-2148](https://workleap.atlassian.net/browse/FENG-2148)

[Jira Story](https://workleap.atlassian.net/browse/FENG-2148)  

## Summary

Enhanced the Jira workflow to support extracting Jira issue keys from PR descriptions when they are not found in the branch name. This provides a more flexible way to link PRs to Jira issues.

## Breaking change: removed `copilot/*` and `claude/*` branch exemptions

Previously, branches matching `copilot/*` and `claude/*` patterns were exempt from Jira validation (early return, no Jira issue required). **This PR intentionally removes those exemptions.** Only `renovate/*` and `gh-readonly-queue/*` branches remain exempt.

With the new fallback mechanism, `copilot/*` and `claude/*` branches can now satisfy Jira enforcement by including a Jira issue key or link in the PR description — they no longer need a free pass. Consumers of this reusable workflow should ensure their bot/automation PRs on these branch patterns include a Jira reference in the PR description.

## Key Changes

- **New extraction step**: Added `Extract Jira Issue from PR description` step that searches PR descriptions for Jira issue keys when branch name extraction fails
  - Searches for Jira URLs (e.g., `https://workleap.atlassian.net/browse/PRJ-123`)
  - Also matches standalone Jira issue keys (e.g., `PRJ-123`)
  - Deduplicates matches and prioritizes URL matches
  - Only runs when branch extraction fails and a PR number is available
- **Improved error messaging**: Updated the error message to guide users on both valid branch naming and PR description formats

## Implementation Details

- The fallback step uses GitHub API to fetch the PR description
- Regex patterns handle both Jira URL format and standalone issue keys
- Uses case-insensitive HashSet to collect unique issue keys
- Outputs results in JSON format for consistency with the existing extraction step
- The fallback only executes when needed, maintaining efficiency

https://claude.ai/code/session_01ATpy7nXy7KvfPcJPyUfdZn



[FENG-2148]: https://workleap.atlassian.net/browse/FENG-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


