### PR TITLE
Add merge_group event support to reusable Semgrep workflow

### DIFF
--- a/.github/workflows/reusable-semgrep-workflow.yml
+++ b/.github/workflows/reusable-semgrep-workflow.yml
@@ -11,37 +11,44 @@ jobs:
       actions: read
       security-events: write
 
+    env:
+      IS_DIFF_SCAN: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+
     container:
       image: returntocorp/semgrep
 
     steps:
       - name: Checkout all commits and tags
         uses: actions/checkout@v5
-        if: ${{ github.event_name  == 'pull_request' }}
+        if: ${{ env.IS_DIFF_SCAN == 'true' }}
         with:
           fetch-depth: 0
 
       - name: Checkout single commit
         uses: actions/checkout@v5
-        if: ${{ github.event_name  != 'pull_request' }}
+        if: ${{ env.IS_DIFF_SCAN != 'true' }}
 
-      - name: Pull request scan
-        if: ${{ github.event_name  == 'pull_request' }}
-        run: semgrep scan --config=auto --verbose --time --error --baseline-commit ${{ github.event.pull_request.base.sha }}
+      - name: Diff scan
+        if: ${{ env.IS_DIFF_SCAN == 'true' }}
+        run: >-
+          semgrep scan --config=auto --verbose --time --error
+          --baseline-commit ${{ github.event_name == 'pull_request'
+            && github.event.pull_request.base.sha
+            || github.event.merge_group.base_sha }}
 
       - name: Full scan
-        if: ${{ github.event_name  != 'pull_request' }}
+        if: ${{ env.IS_DIFF_SCAN != 'true' }}
         run: semgrep scan --config=auto --verbose --time --sarif --output report.sarif
 
       - name: Save report as pipeline artifact
-        if: ${{ github.event_name  != 'pull_request' }}
+        if: ${{ env.IS_DIFF_SCAN != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: report.sarif
           path: report.sarif
 
       - name: Publish code scanning alerts
-        if: ${{ github.event_name  != 'pull_request' }}
+        if: ${{ env.IS_DIFF_SCAN != 'true' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: report.sarif


### PR DESCRIPTION
> [!NOTE]
> I tested the workflow in my repo, targetting this branch specifically, and it worked perfectly 👌. As soon as this PR merges, i'll update my repo's workflow to target the latest version

## Context
We want to start using merge queues in ShareGate Protect. The way the reusable Semgrep workflow is currently set up, a `merge_group` event falls into the non-`pull_request` branch, which causes a full repo scan instead of a targeted diff scan. This is slower, produces noise unrelated to the PR's changes, and uploads unnecessary SARIF reports to code scanning alerts.

## Summary
- Adds `merge_group` event handling to the reusable Semgrep workflow so it runs a **diff scan** (not a full scan) when triggered from a merge queue
- Centralizes the diff-scan vs full-scan condition in a job-level `IS_DIFF_SCAN` env var, replacing repeated `github.event_name` checks
- Uses a ternary expression to pick the correct baseline SHA (`pull_request.base.sha` or `merge_group.base_sha`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)