### PR TITLE
Validate Renovate GitHub PAT before running Renovate

### DIFF
--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -80,6 +80,26 @@ jobs:
             exit 1
           fi
 
+      - name: Verify exactly one private/internal repository is accessible
+        shell: bash
+        env:
+          PAT: ${{ steps.get_github_secret.outputs.secret }}
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp)
+          trap 'rm -f "$tmp"' EXIT
+          curl --silent --fail --show-error \
+            -H "Authorization: Bearer $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/workleap/repos?type=private&per_page=100" \
+            -o "$tmp"
+          count=$(jq '[.[] | select(.visibility == "private" or .visibility == "internal")] | length' "$tmp")
+          if [ "$count" -ne 1 ]; then
+            echo "::error::Expected exactly one private/internal repository accessible by the PAT, got $count."
+            exit 1
+          fi
+
       - name: Get renovate-tfc-token secret
         id: get_terraform_secret
         uses: workleap/wl-reusable-workflows/retrieve-managed-secret@main

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -43,7 +43,24 @@ jobs:
           azure-subscription-id: ${{ vars.WORKLEAP_GLOBAL_KEYVAULT_SUBSCRIPTION_ID }}
           keyvault-name: ${{ vars.WORKLEAP_GLOBAL_KEYVAULT_NAME }}
           secret-name: "renovate-github-pat"
-      
+
+      - name: Validate GitHub PAT
+        shell: bash
+        env:
+          PAT: ${{ steps.get_github_secret.outputs.secret }}
+        run: |
+          set -euo pipefail
+          status=$(curl --silent --output /dev/null --write-out "%{http_code}" \
+            -H "Authorization: Bearer $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/workleap/wl-reusable-workflows/contents/renovate.cli.json)
+          echo "GitHub API returned HTTP $status"
+          if [ "$status" != "200" ]; then
+            echo "::error::Renovate GitHub PAT validation failed (HTTP $status). The token retrieved from Key Vault is missing, invalid, expired, or lacks 'contents:read' on workleap/wl-reusable-workflows."
+            exit 1
+          fi
+
       - name: Get renovate-tfc-token secret
         id: get_terraform_secret
         uses: workleap/wl-reusable-workflows/retrieve-managed-secret@main

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -61,6 +61,25 @@ jobs:
             exit 1
           fi
 
+      - name: List workleap org repositories with PAT
+        shell: bash
+        env:
+          PAT: ${{ steps.get_github_secret.outputs.secret }}
+        run: |
+          set -euo pipefail
+          response=$(curl --silent --fail --show-error \
+            -H "Authorization: Bearer $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/workleap/repos?per_page=100")
+          count=$(echo "$response" | jq 'length')
+          echo "Found $count repositories in the workleap organization:"
+          echo "$response" | jq -r '.[].full_name'
+          if [ "$count" -le 10 ]; then
+            echo "::error::Expected more than 10 repositories listed from the workleap org, got $count. The PAT likely lacks org-level read access."
+            exit 1
+          fi
+
       - name: Get renovate-tfc-token secret
         id: get_terraform_secret
         uses: workleap/wl-reusable-workflows/retrieve-managed-secret@main

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -61,25 +61,6 @@ jobs:
             exit 1
           fi
 
-      - name: List workleap org repositories with PAT
-        shell: bash
-        env:
-          PAT: ${{ steps.get_github_secret.outputs.secret }}
-        run: |
-          set -euo pipefail
-          response=$(curl --silent --fail --show-error \
-            -H "Authorization: Bearer $PAT" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/orgs/workleap/repos?per_page=100")
-          count=$(echo "$response" | jq 'length')
-          echo "Found $count repositories in the workleap organization:"
-          echo "$response" | jq -r '.[].full_name'
-          if [ "$count" -le 10 ]; then
-            echo "::error::Expected more than 10 repositories listed from the workleap org, got $count. The PAT likely lacks org-level read access."
-            exit 1
-          fi
-
       - name: Verify exactly one private/internal repository is accessible
         shell: bash
         env:
@@ -95,8 +76,8 @@ jobs:
             "https://api.github.com/orgs/workleap/repos?type=private&per_page=100" \
             -o "$tmp"
           count=$(jq '[.[] | select(.visibility == "private" or .visibility == "internal")] | length' "$tmp")
-          if [ "$count" -ne 1 ]; then
-            echo "::error::Expected exactly one private/internal repository accessible by the PAT, got $count."
+          if [ "$count" -le 10 ]; then
+            echo "::error::Expected private/internal repositories accessible by the PAT, got $count."
             exit 1
           fi
 


### PR DESCRIPTION
Jira issue link: [SSD-5258](https://workleap.atlassian.net/browse/SSD-5258)

https://workleap.atlassian.net/browse/SSD-5258

## Summary
- Adds a `Validate GitHub PAT` step in `reusable-renovate-workflow.yml` immediately after the `renovate-github-pat` secret is retrieved.
- The step calls `GET /repos/workleap/wl-reusable-workflows/contents/renovate.cli.json` with the PAT and fails the job with an `::error::` annotation if the response is not HTTP 200.
- Goal: surface PAT issues (missing, invalid, expired, or insufficient `contents:read` scope) with a clear, isolated error instead of having them appear deep inside `npx renovate` logs.

## Notes
- The PAT is passed via `env:` (not `${{ ... }}` interpolation inside `run`) so it stays out of the rendered shell command and remains masked.
- Uses modern `Authorization: Bearer` and the recommended `Accept` / `X-GitHub-Api-Version` headers.

## Test plan
- [ ] CI: the `renovate` job runs on this PR (triggered by changes to `reusable-renovate-workflow.yml`).
- [ ] The new "Validate GitHub PAT" step logs `GitHub API returned HTTP 200` and the workflow continues.
- [ ] If the PAT is actually broken, the step fails early with the `::error::` annotation and `npx renovate` is not executed.



[SSD-5258]: https://workleap.atlassian.net/browse/SSD-5258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ