### PR TITLE
Extend Renovate scheduled runs to Saturday and Sunday

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,22 +13,22 @@ on:
       - .github/workflows/reusable-renovate-workflow.yml
       - renovate.cli.json
   schedule:
-    - cron: "0 22 * * 6"  # B01 —  5:00 PM EST — ov-monorepo [dedicated]
-    - cron: "0 23 * * 6"  # B02 —  6:00 PM EST — wlp-monorepo [dedicated]
-    - cron: "0 0 * * 6"   # B03 —  7:00 PM EST — ov- (excl. monorepo) ~13 repos
-    - cron: "0 1 * * 6"   # B04 —  8:00 PM EST — wlp- (excl. monorepo) ~17 repos
-    - cron: "0 2 * * 6"   # B05 —  9:00 PM EST — sg- (excl. sg-migrate-) ~27 repos
-    - cron: "0 3 * * 6"   # B06 — 10:00 PM EST — sg-migrate- ~24 repos
-    - cron: "0 4 * * 6"   # B07 — 11:00 PM EST — wl-[a-c] ~20 repos
-    - cron: "30 4 * * 6"  # B08 — 11:30 PM EST — wl-d ~18 repos
-    - cron: "0 5 * * 6"   # B09 — 12:00 AM EST — wl-[e-h] ~26 repos
-    - cron: "30 5 * * 6"  # B10 — 12:30 AM EST — wl-[i-l] ~20 repos
-    - cron: "0 6 * * 6"   # B11 —  1:00 AM EST — wl-[m-p] ~25 repos
-    - cron: "30 6 * * 6"  # B12 —  1:30 AM EST — wl-[q-z] ~23 repos
-    - cron: "0 7 * * 6"   # B13 —  2:00 AM EST — terraform-azurerm-enterprise-[a-e] ~16 repos
-    - cron: "30 7 * * 6"  # B14 —  2:30 AM EST — terraform-azurerm-enterprise-[f-z] ~21 repos
-    - cron: "0 8 * * 6"   # B15 —  3:00 AM EST — terraform non-azurerm enterprise/vertical ~20 repos
-    - cron: "0 9 * * 6"   # B16 —  4:00 AM EST — catch-all ~51 repos
+    - cron: "0 22 * * 6,0"  # B01 —  5:00 PM EST — ov-monorepo [dedicated]
+    - cron: "0 23 * * 6,0"  # B02 —  6:00 PM EST — wlp-monorepo [dedicated]
+    - cron: "0 0 * * 6,0"   # B03 —  7:00 PM EST — ov- (excl. monorepo) ~13 repos
+    - cron: "0 1 * * 6,0"   # B04 —  8:00 PM EST — wlp- (excl. monorepo) ~17 repos
+    - cron: "0 2 * * 6,0"   # B05 —  9:00 PM EST — sg- (excl. sg-migrate-) ~27 repos
+    - cron: "0 3 * * 6,0"   # B06 — 10:00 PM EST — sg-migrate- ~24 repos
+    - cron: "0 4 * * 6,0"   # B07 — 11:00 PM EST — wl-[a-c] ~20 repos
+    - cron: "30 4 * * 6,0"  # B08 — 11:30 PM EST — wl-d ~18 repos
+    - cron: "0 5 * * 6,0"   # B09 — 12:00 AM EST — wl-[e-h] ~26 repos
+    - cron: "30 5 * * 6,0"  # B10 — 12:30 AM EST — wl-[i-l] ~20 repos
+    - cron: "0 6 * * 6,0"   # B11 —  1:00 AM EST — wl-[m-p] ~25 repos
+    - cron: "30 6 * * 6,0"  # B12 —  1:30 AM EST — wl-[q-z] ~23 repos
+    - cron: "0 7 * * 6,0"   # B13 —  2:00 AM EST — terraform-azurerm-enterprise-[a-e] ~16 repos
+    - cron: "30 7 * * 6,0"  # B14 —  2:30 AM EST — terraform-azurerm-enterprise-[f-z] ~21 repos
+    - cron: "0 8 * * 6,0"   # B15 —  3:00 AM EST — terraform non-azurerm enterprise/vertical ~20 repos
+    - cron: "0 9 * * 6,0"   # B16 —  4:00 AM EST — catch-all ~51 repos
 
 jobs:
   determine-filter:
@@ -49,31 +49,31 @@ jobs:
             $schedule = "${{ github.event.schedule }}"
             switch ($schedule) {
               # ── Dedicated monorepo slots ──
-              "0 22 * * 6" { "filter=workleap/ov-monorepo" >> $env:GITHUB_OUTPUT }
-              "0 23 * * 6" { "filter=workleap/wlp-monorepo" >> $env:GITHUB_OUTPUT }
+              "0 22 * * 6,0" { "filter=workleap/ov-monorepo" >> $env:GITHUB_OUTPUT }
+              "0 23 * * 6,0" { "filter=workleap/wlp-monorepo" >> $env:GITHUB_OUTPUT }
 
               # ── Product prefixes ──
-              "0 0 * * 6"  { "filter=/^workleap\/ov-(?!monorepo$).*$/" >> $env:GITHUB_OUTPUT }
-              "0 1 * * 6"  { "filter=/^workleap\/wlp-(?!monorepo$).*$/" >> $env:GITHUB_OUTPUT }
-              "0 2 * * 6"  { "filter=/^workleap\/sg-(?!migrate-).*$/" >> $env:GITHUB_OUTPUT }
-              "0 3 * * 6"  { "filter=workleap/sg-migrate-*" >> $env:GITHUB_OUTPUT }
+              "0 0 * * 6,0"  { "filter=/^workleap\/ov-(?!monorepo$).*$/" >> $env:GITHUB_OUTPUT }
+              "0 1 * * 6,0"  { "filter=/^workleap\/wlp-(?!monorepo$).*$/" >> $env:GITHUB_OUTPUT }
+              "0 2 * * 6,0"  { "filter=/^workleap\/sg-(?!migrate-).*$/" >> $env:GITHUB_OUTPUT }
+              "0 3 * * 6,0"  { "filter=workleap/sg-migrate-*" >> $env:GITHUB_OUTPUT }
 
               # ── wl- (6 balanced buckets) ──
-              "0 4 * * 6"  { "filter=/^workleap\/wl-[a-c].*$/" >> $env:GITHUB_OUTPUT }
-              "30 4 * * 6" { "filter=/^workleap\/wl-d.*$/" >> $env:GITHUB_OUTPUT }
-              "0 5 * * 6"  { "filter=/^workleap\/wl-[e-h].*$/" >> $env:GITHUB_OUTPUT }
-              "30 5 * * 6" { "filter=/^workleap\/wl-[i-l].*$/" >> $env:GITHUB_OUTPUT }
-              "0 6 * * 6"  { "filter=/^workleap\/wl-[m-p].*$/" >> $env:GITHUB_OUTPUT }
-              "30 6 * * 6" { "filter=/^workleap\/wl-[q-z].*$/" >> $env:GITHUB_OUTPUT }
+              "0 4 * * 6,0"  { "filter=/^workleap\/wl-[a-c].*$/" >> $env:GITHUB_OUTPUT }
+              "30 4 * * 6,0" { "filter=/^workleap\/wl-d.*$/" >> $env:GITHUB_OUTPUT }
+              "0 5 * * 6,0"  { "filter=/^workleap\/wl-[e-h].*$/" >> $env:GITHUB_OUTPUT }
+              "30 5 * * 6,0" { "filter=/^workleap\/wl-[i-l].*$/" >> $env:GITHUB_OUTPUT }
+              "0 6 * * 6,0"  { "filter=/^workleap\/wl-[m-p].*$/" >> $env:GITHUB_OUTPUT }
+              "30 6 * * 6,0" { "filter=/^workleap\/wl-[q-z].*$/" >> $env:GITHUB_OUTPUT }
 
               # ── Terraform modules (3 balanced buckets) ──
-              "0 7 * * 6"  { "filter=/^workleap\/terraform-azurerm-enterprise-[a-e].*$/" >> $env:GITHUB_OUTPUT }
-              "30 7 * * 6" { "filter=/^workleap\/terraform-azurerm-enterprise-[f-z].*$/" >> $env:GITHUB_OUTPUT }
-              "0 8 * * 6"  { "filter=/^workleap\/terraform-(?!azurerm-enterprise).*-(enterprise|vertical)-.*$/" >> $env:GITHUB_OUTPUT }
+              "0 7 * * 6,0"  { "filter=/^workleap\/terraform-azurerm-enterprise-[a-e].*$/" >> $env:GITHUB_OUTPUT }
+              "30 7 * * 6,0" { "filter=/^workleap\/terraform-azurerm-enterprise-[f-z].*$/" >> $env:GITHUB_OUTPUT }
+              "0 8 * * 6,0"  { "filter=/^workleap\/terraform-(?!azurerm-enterprise).*-(enterprise|vertical)-.*$/" >> $env:GITHUB_OUTPUT }
 
               # ── Catch-all (everything not matched above) ──
               # Excludes: ov-*, wlp-*, sg-*, wl-*, and all terraform-* repos
-              "0 9 * * 6"  { "filter=workleap/!(ov-*|sg-*|wlp-*|wl-*|terraform-*)" >> $env:GITHUB_OUTPUT }
+              "0 9 * * 6,0"  { "filter=workleap/!(ov-*|sg-*|wlp-*|wl-*|terraform-*)" >> $env:GITHUB_OUTPUT }
 
               default { throw "Unexpected schedule: $schedule" }
             }


### PR DESCRIPTION
Jira issue link: [SSD-5343](https://workleap.atlassian.net/browse/SSD-5343)

SSD-5343

## Summary
- Update the 16 Renovate scheduled buckets in `.github/workflows/renovate.yml` to run on both Saturday and Sunday (`* * * 6,0`) instead of Saturday only (`* * * 6`).
- Update the matching `switch` cases in the `determine-filter` step so the filter lookup still resolves at runtime.

## Why
Doubles the weekly Renovate windows so updates that don't land on Saturday get a second chance on Sunday, without changing time-of-day slotting or the per-bucket filters.

Also, auto-merge create a branch first, and merge it the next run when the pipeline succeeds, or create a PR when it fails. Running it twice a week increase the rate of merging.

## Test plan
- [ ] Confirm the workflow's `cron` entries are valid and visible under the Actions tab after merge.
- [ ] On the next Saturday/Sunday run, verify a bucket triggers and `determine-filter` emits the expected filter (no `Unexpected schedule` throw).


[SSD-5343]: https://workleap.atlassian.net/browse/SSD-5343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ