### PR TITLE
[SGD-24733] Upgrade Renovate CLI to v44 and pin version for reproducible runs

### DIFF
--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -113,10 +113,10 @@ jobs:
 
       - name: ${{ inputs.workflow_name }}
         shell: bash
-        # Using @latest ensures we always run a supported Renovate version.
-        # Without it, npx resolves whatever version is in the npm cache, which
-        # can silently fall behind (e.g. v42.99.0 was cached while v43+ was already out).
-        run: npx renovate@latest
+        # Version is pinned so runs are reproducible and a bad Renovate release
+        # cannot silently break the workflow. Renovate itself opens a PR to bump
+        # this value when a new version is published (see renovate.json customManagers).
+        run: npx renovate@43.245.0
         env:
           RENOVATE_CONFIG_FILE: ${{ inputs.config_file }}
           LOG_FILE: ${{ inputs.log_file }}

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -105,14 +105,14 @@ jobs:
         with:
           version: 10
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: ${{ inputs.workflow_name }}
         shell: bash
-        run: npx renovate
+        run: npx renovate@latest
         env:
           RENOVATE_CONFIG_FILE: ${{ inputs.config_file }}
           LOG_FILE: ${{ inputs.log_file }}

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -116,7 +116,7 @@ jobs:
         # Version is pinned so runs are reproducible and a bad Renovate release
         # cannot silently break the workflow. Renovate itself opens a PR to bump
         # this value when a new version is published (see renovate.json customManagers).
-        run: npx --yes renovate@43.245.0
+        run: npx --yes renovate@44.48.0
         env:
           RENOVATE_CONFIG_FILE: ${{ inputs.config_file }}
           LOG_FILE: ${{ inputs.log_file }}

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           version: 10
 
+      # Node.js 24 is required by Renovate v43+. v43 dropped support for Node 22.
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
@@ -112,6 +113,9 @@ jobs:
 
       - name: ${{ inputs.workflow_name }}
         shell: bash
+        # Using @latest ensures we always run a supported Renovate version.
+        # Without it, npx resolves whatever version is in the npm cache, which
+        # can silently fall behind (e.g. v42.99.0 was cached while v43+ was already out).
         run: npx renovate@latest
         env:
           RENOVATE_CONFIG_FILE: ${{ inputs.config_file }}

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: [idp]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get renovate-github-pat secret
         id: get_github_secret
@@ -101,13 +101,13 @@ jobs:
           keyvault-name: ${{ vars.IDP_CICD_KEYVAULT_NAME }}
           secret-name: "renovate-ado-feed-pat"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
       # Node.js 24 is required by Renovate v43+. v43 dropped support for Node 22.
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/reusable-renovate-workflow.yml
+++ b/.github/workflows/reusable-renovate-workflow.yml
@@ -116,7 +116,7 @@ jobs:
         # Version is pinned so runs are reproducible and a bad Renovate release
         # cannot silently break the workflow. Renovate itself opens a PR to bump
         # this value when a new version is published (see renovate.json customManagers).
-        run: npx renovate@43.245.0
+        run: npx --yes renovate@43.245.0
         env:
           RENOVATE_CONFIG_FILE: ${{ inputs.config_file }}
           LOG_FILE: ${{ inputs.log_file }}

--- a/az-artifact-authenticate/action.yml
+++ b/az-artifact-authenticate/action.yml
@@ -45,7 +45,7 @@ runs:
         }
 
     - name: 'Azure CLI login'
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.client-id || fromJSON(inputs.variables).AZURE_CLIENT_ID }}
         tenant-id: ${{ inputs.tenant-id || fromJSON(inputs.variables).AZURE_TENANT_ID }}

--- a/az-npm-registry-authenticate/action.yml
+++ b/az-npm-registry-authenticate/action.yml
@@ -41,7 +41,7 @@ runs:
         }
 
     - name: 'Azure CLI login'
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.client-id || fromJSON(inputs.variables).AZURE_CLIENT_ID }}
         tenant-id: ${{ inputs.tenant-id || fromJSON(inputs.variables).AZURE_TENANT_ID }}

--- a/renovate.cli.json
+++ b/renovate.cli.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "CLI configuration for Renovate workflow - discovers repositories within the workleap organisation that contain a Renovate configuration file, and executes Renovate by using each individual repository configuration. Repository filter is controlled via RENOVATE_AUTODISCOVER_FILTER environment variable.",
+  "description": [
+    "CLI configuration for Renovate workflow - discovers repositories within the workleap organisation that contain a Renovate configuration file, and executes Renovate by using each individual repository configuration. Repository filter is controlled via RENOVATE_AUTODISCOVER_FILTER environment variable.",
+    "allowShellExecutorForPostUpgradeCommands: Renovate v43 removed shell execution for postUpgradeTasks commands by default as a security hardening measure. This restores the previous behavior so that existing postUpgradeTasks using shell syntax (&&, |, $VAR, globs, etc.) across company repos continue to work after the v43 upgrade."
+  ],
   "extends": [
     "github>workleap/renovate-config"
   ],

--- a/renovate.cli.json
+++ b/renovate.cli.json
@@ -30,5 +30,6 @@
     }
   ],
   "optimizeForDisabled": true,
-  "onboarding": false
+  "onboarding": false,
+  "allowShellExecutorForPostUpgradeCommands": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,15 @@
   ],
   "allowedCommands": [
     "^terraform-docs markdown table --output-file README\\.md --hide resources,data-sources \\.\/?$"
+  ],
+  "customManagers": [
+    {
+      "description": "Keep the pinned Renovate CLI version in the reusable workflow up to date. Renovate detects the version from the npx renovate@X.Y.Z call and opens a PR when a new npm release is available.",
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/reusable-renovate-workflow\\.yml$"],
+      "matchStrings": ["npx renovate@(?<currentValue>[^\\s]+)"],
+      "depNameTemplate": "renovate",
+      "datasourceTemplate": "npm"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "description": "Keep the pinned Renovate CLI version in the reusable workflow up to date. Renovate detects the version from the npx renovate@X.Y.Z call and opens a PR when a new npm release is available.",
       "customType": "regex",
       "fileMatch": ["^\\.github/workflows/reusable-renovate-workflow\\.yml$"],
-      "matchStrings": ["npx renovate@(?<currentValue>[^\\s]+)"],
+      "matchStrings": ["npx (?:--yes |-y )?renovate@(?<currentValue>[^\\s]+)"],
       "depNameTemplate": "renovate",
       "datasourceTemplate": "npm"
     }

--- a/retrieve-managed-secret/action.yml
+++ b/retrieve-managed-secret/action.yml
@@ -43,7 +43,7 @@ runs:
         }
 
     - name: 'Azure CLI login'
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}


### PR DESCRIPTION
Jira issue link: [SGD-24733](https://workleap.atlassian.net/browse/SGD-24733)

SGD-24733

## Summary

- Upgrade Node.js from 22 to 24 in the reusable Renovate workflow (required by Renovate v43+)
- Pin the Renovate CLI to `44.48.0` instead of using an unpinned `npx renovate` call
- Add a `customManagers` regex entry in `renovate.json` so Renovate opens a PR on this repo automatically when a new CLI version is published on npm
- Add `allowShellExecutorForPostUpgradeCommands: true` to `renovate.cli.json` to preserve existing behavior across company repos
- Bump `actions/checkout` (v5→v7), `actions/setup-node` (v4→v7), `pnpm/action-setup` (v4→v6), and `azure/login` (v2→v3, in the shared `retrieve-managed-secret` action) to their latest majors

## Why

The workflow was running `npx renovate` with no version pinned. npm was resolving `42.99.0` from its cache — a version that is now deprecated and unsupported by the Renovate team (v43+ has been released). This caused a wall of deprecation warnings on every Renovate run.

Pinning to a specific version makes runs reproducible and prevents a bad Renovate release from silently breaking all company workflows. The regex `customManager` takes care of keeping the pin up to date going forward, matching the [officially recommended self-hosting pattern](https://github.com/renovatebot/github-action).

Pinned to `44.48.0` (current latest) rather than `43.245.0`. Renovate `44.0.0` was released as a major version by mistake — a stray "BREAKING CHANGE" mention in a commit message tripped semantic-release — and the [maintainers confirmed](https://github.com/renovatebot/renovate/discussions/44952) there are no actual breaking changes between 43.x and 44.x, treating 44 as a continuation of 43.

`allowShellExecutorForPostUpgradeCommands` is required because Renovate v43 removed shell execution for `postUpgradeTasks` commands by default as a security hardening measure. Without it, any company repo using shell syntax (`&&`, `|`, `$VAR`, globs, etc.) in `postUpgradeTasks` would silently break after this upgrade.

`actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, and `azure/login` all still declared `runs.using: node20` in their older major versions. Since Node 20 support on GitHub-hosted runners is being [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), those actions now run on the Node 24 runtime anyway, with a deprecation warning logged on every run. Their latest majors all declare `runs.using: node24`, so bumping them clears the warning with no functional changes.

## Test plan

- [ ] Confirm the next scheduled Renovate run no longer shows `npm warn deprecated renovate@...` warnings in the logs
- [ ] Confirm Renovate completes successfully against its normal repo set
- [ ] Confirm a future Renovate version bump (e.g. `44.49.0`) triggers a PR on this repo via the new `customManagers` rule
- [ ] Confirm the Node 20 deprecation warning no longer appears in the workflow run logs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGTTYDudBaBAQPDnhRXV4s)_

[SGD-24733]: https://workleap.atlassian.net/browse/SGD-24733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ







