### PR TITLE
Add Renovate replacement rule for Azure/naming to Workleap fork

### DIFF
--- a/renovate-terraform-infra.json
+++ b/renovate-terraform-infra.json
@@ -7,5 +7,15 @@
   "autodiscover": true,
   "autodiscoverFilter": [
     "workleap/wl-terraform-*"
+  ],
+  "packageRules": [
+    {
+      "description": "FENG-2646: migrate Azure/naming to the Workleap fork, which drops two billable random_string resources per module instance. Scoped to 0.4.2/0.4.3 because the fork is cut from 0.4.3: lower pins (0.2.0/0.3.0/0.4.0 in wl-terraform-wlplatform) cross upstream naming changes that would rename live Azure resources, and the `~> 0.4` ranges in wl-terraform-ittech would be rewritten to `~> 1.0` rather than pinned. Those six blocks are handled by hand. Remove this rule once the estate is migrated.",
+      "matchDatasources": ["terraform-module"],
+      "matchPackageNames": ["Azure/naming/azurerm"],
+      "matchCurrentValue": "/^0\\.4\\.[23]$/",
+      "replacementName": "app.terraform.io/Workleap/naming/azurerm",
+      "replacementVersion": "1.0.0"
+    }
   ]
 }

--- a/renovate-terraform-infra.json
+++ b/renovate-terraform-infra.json
@@ -10,12 +10,20 @@
   ],
   "packageRules": [
     {
-      "description": "FENG-2646: migrate Azure/naming to the Workleap fork, which drops two billable random_string resources per module instance. Scoped to 0.4.2/0.4.3 because the fork is cut from 0.4.3: lower pins (0.2.0/0.3.0/0.4.0 in wl-terraform-wlplatform) cross upstream naming changes that would rename live Azure resources, and the `~> 0.4` ranges in wl-terraform-ittech would be rewritten to `~> 1.0` rather than pinned. Those six blocks are handled by hand. Remove this rule once the estate is migrated.",
+      "description": "FENG-2646: migrate Azure/naming to the Workleap fork. Scoped to 0.4.2/0.4.3; six lower or ranged pins are migrated by hand. Remove this rule once the estate is migrated.",
       "matchDatasources": ["terraform-module"],
       "matchPackageNames": ["Azure/naming/azurerm"],
       "matchCurrentValue": "/^0\\.4\\.[23]$/",
       "replacementName": "app.terraform.io/Workleap/naming/azurerm",
       "replacementVersion": "1.0.0"
+    },
+    {
+      "description": "FENG-2646 carve-out: wl-ai feeds name_unique into live data stores, so a seed change would force destroy/recreate across ai-dev/stg/prod. These instances stay on upstream.",
+      "matchDatasources": ["terraform-module"],
+      "matchPackageNames": ["Azure/naming/azurerm"],
+      "matchRepositories": ["workleap/wl-terraform-lab"],
+      "matchFileNames": ["wl-ai/modules/**"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Jira issue link: [FENG-2646](https://workleap.atlassian.net/browse/FENG-2646)

## What

Adds a `packageRules` replacement entry to `renovate-terraform-infra.json` that migrates
`Azure/naming/azurerm` → `app.terraform.io/Workleap/naming/azurerm` `1.0.0` across the
autodiscovered `workleap/wl-terraform-*` infrastructure repos.

## Why

`Azure/naming/azurerm` declares two unconditional `random_string` resources per module
instance (`random_string.main`, `random_string.first_letter`). Only the `name_unique` outputs
consume them, so for nearly every consumer they are inert — but HCP Terraform bills
$0.47/month per managed resource. A full enumeration of all 455 workspaces found 4,470
`random_*` resources out of 27,110 billable (16.5%), ≈$2,101/month ≈ $25,200/year.

The Workleap fork (`workleap/terraform-azurerm-naming` `1.0.0`) replaces those two resources
with a deterministic `sha256(prefix-suffix)` seed plus a hex→`a-p` map that preserves
upstream's "seed starts with a letter" guarantee (required by the `^[a-z][a-z0-9]+$` name
regexes). The interface is unchanged; `unique-include-numbers` becomes inert.

## Scoping

`matchCurrentValue` is deliberately limited to `0.4.2`/`0.4.3` because the fork is cut from
`0.4.3`:

- Lower pins (`0.2.0`/`0.3.0`/`0.4.0` in `wl-terraform-wlplatform`) cross upstream naming
  changes that would rename live Azure resources.
- The `~> 0.4` ranges in `wl-terraform-ittech` would be rewritten to `~> 1.0` rather than
  pinned.

Those six blocks are handled by hand. `renovate-terraform.json` is intentionally untouched —
the 35 enterprise module repos are a later wave, gated on fork hardening in
`workleap/terraform-azurerm-naming`.

## Downstream impact

`renovate-terraform-infra.json` is the global config (`RENOVATE_CONFIG_FILE`) and `forceCli`
defaults true, so this rule applies to every autodiscovered repo regardless of its own
`renovate.json`. This workflow triggers on `pull_request` touching this file and there is no
`dryRun`, so opening this PR runs the sweep for real: expect replacement PRs in
`wl-terraform-{infrastructure,ittech,lab,hrtech}` (~39 blocks).

Expected plan shape on each consumer PR: `random_string` destroys only, 0 creates, 0
replacements. No `moved` blocks needed — the module block name is unchanged. `terraform-plan-diff`
will go red on those PRs; it is a commit status, not a required check, and module replacements
are not automerge-eligible, so each downstream PR needs human approval plus code-owner review.

Remove this rule once the estate is migrated.

FENG-2646: https://workleap.atlassian.net/browse/FENG-2646


[FENG-2646]: https://workleap.atlassian.net/browse/FENG-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


